### PR TITLE
debug assertions for copy_fast

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -91,11 +91,13 @@ pub fn rgb888_to_rgb1555_scalar(rgb888_pixels: &[u8], rgb1555_pixels: &mut [u8])
             rgb888_pixels[index * RGB_SIZE + 2],
         );
         let rgb1555 = rgb888_to_rgb1555(r, g, b);
-        copy_fast(
-            &rgb1555,
-            &mut rgb1555_pixels[index * RGB1555_SIZE..index * RGB1555_SIZE + 1],
-            RGB565_SIZE,
-        )
+        unsafe {
+            copy_fast(
+                &rgb1555,
+                &mut rgb1555_pixels[index * RGB1555_SIZE..index * RGB1555_SIZE + RGB565_SIZE],
+                RGB565_SIZE,
+            )
+        }
     }
 }
 
@@ -215,11 +217,13 @@ pub fn rgb888_to_rgb1555_simd(rgb888_pixels: &[u8], rgb1555_pixels: &mut [u8]) {
         );
         let rgb1555 = rgb888_to_rgb1555(r, g, b);
         let output_offset = offset_rgb1555 + index * RGB565_SIZE;
-        copy_fast(
-            &rgb1555,
-            &mut rgb1555_pixels[output_offset..output_offset + 1],
-            RGB565_SIZE,
-        );
+        unsafe {
+            copy_fast(
+                &rgb1555,
+                &mut rgb1555_pixels[output_offset..output_offset + RGB565_SIZE],
+                RGB565_SIZE,
+            );
+        }
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -118,12 +118,13 @@ pub fn save_bmp(path: &str, pixels: &[u8], width: u32, height: u32) -> Result<()
 ///
 /// This function is optimized for performance and uses pointer-based
 /// operations to copy the data as fast as possible.
-pub fn copy_fast(src: &[u8], dst: &mut [u8], count: usize) {
-    unsafe {
-        let src_ptr = src.as_ptr();
-        let dst_ptr = dst.as_mut_ptr();
-        std::ptr::copy_nonoverlapping(src_ptr, dst_ptr, count);
-    }
+pub unsafe fn copy_fast(src: &[u8], dst: &mut [u8], count: usize) {
+    debug_assert!(src.len() >= count);
+    debug_assert!(dst.len() >= count);
+
+    let src_ptr = src.as_ptr();
+    let dst_ptr = dst.as_mut_ptr();
+    std::ptr::copy_nonoverlapping(src_ptr, dst_ptr, count);
 }
 
 // Interleaves two arrays of bytes into a single array using


### PR DESCRIPTION
Hi, while playing with your code I've noticed that you use `copy_fast` with a `dst` slice which length is lesser than `count`.

I don't think it was causing undefined behavior, but I've fixed the parameters anyway. I've added some debug assertions too.

I've marked `copy_fast` as unsafe as it still is for release builds.
