### PR TITLE
Implement HBlank DMA timing

### DIFF
--- a/frontends/sdl/src/main.rs
+++ b/frontends/sdl/src/main.rs
@@ -584,7 +584,7 @@ impl Emulator {
                                     self.load_state(&file_path);
                                 }
                             }
-                            _ => {}
+                            _ => (),
                         }
                         if let Some(key) = key_to_pad(keycode) {
                             self.system.key_press(key)

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -258,6 +258,14 @@ impl Dma {
         self.cycles_dma = value;
     }
 
+    pub fn cycles_hdma(&self) -> u16 {
+        self.cycles_hdma
+    }
+
+    pub fn set_cycles_hdma(&mut self, value: u16) {
+        self.cycles_hdma = value;
+    }
+
     pub fn active_dma(&self) -> bool {
         self.active_dma
     }

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -432,7 +432,7 @@ mod tests {
         };
 
         let state = dma.state(None).unwrap();
-        assert_eq!(state.len(), 14);
+        assert_eq!(state.len(), 16);
 
         let mut new_dma = Dma::new();
         new_dma.set_state(&state, None).unwrap();

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -107,7 +107,11 @@ pub struct Dma {
     /// DMA operation.
     value_dma: u8,
 
+    /// Number of CPU cycles remaining for the OAM DMA operation.
     cycles_dma: u16,
+
+    /// Number of CPU cycles remaining for the HDMA operation.
+    /// Only used in the HDMA operation.
     cycles_hdma: u16,
 
     /// Indicates whether the (OAM) DMA operation is currently active.
@@ -194,7 +198,7 @@ impl Dma {
                     self.length = (((value & 0x7f) + 0x1) as u16) << 4;
                     self.mode = ((value & 0x80) >> 7).into();
                     self.pending = self.length;
-                    self.cycles_hdma = HDMA_CYCLES_PER_BLOCK;
+                    self.cycles_hdma = 0xffff;
                     self.active_hdma = true;
                 }
             }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -330,7 +330,6 @@ impl Mmu {
                 DmaMode::HBlank
                     if self.dma.mode() == DmaMode::HBlank && self.ppu.mode() == PpuMode::HBlank =>
                 {
-                    println!("HDMA transfer in HBlank mode, cycles: {}", cycles);
                     // in case the cycles value is 0xffff, it means that the
                     // HDMA transfer is just getting started, so we set the
                     // cycles to the `HDMA_CYCLES_PER_BLOCK`` value, this is done

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -351,6 +351,7 @@ impl Mmu {
                         self.dma.set_cycles_dma(cycles_dma);
                     }
                 }
+                _ => (),
             }
         }
     }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -315,39 +315,28 @@ impl Mmu {
                 self.dma.destination()
             );
 
-            match self.dma.mode() {
-                DmaMode::General => {
+            if self.dma.mode() == DmaMode::General
+                || (self.dma.mode() == DmaMode::HBlank && self.ppu.mode() == PpuMode::HBlank)
+            {
+                let cycles_dma = self.dma.cycles_hdma().saturating_sub(cycles);
+                if cycles_dma == 0x0 {
+                    let count = 0x10.min(self.dma.pending());
                     if self.mode == GameBoyMode::Cgb {
-                        let data = self.read_many(self.dma.source(), self.dma.pending());
+                        let data = self.read_many(self.dma.source(), count);
                         self.write_many(self.dma.destination(), &data);
                     }
-                    self.dma.set_pending(0);
-                    self.dma.set_active_hdma(false);
-                }
-                DmaMode::HBlank => {
-                    if self.dma.cycles_dma() == 0 && self.ppu.mode() == PpuMode::HBlank {
+                    self.dma.set_source(self.dma.source().wrapping_add(count));
+                    self.dma
+                        .set_destination(self.dma.destination().wrapping_add(count));
+                    self.dma
+                        .set_pending(self.dma.pending().saturating_sub(count));
+                    if self.dma.pending() == 0x0 {
+                        self.dma.set_active_hdma(false);
+                    } else {
                         self.dma.set_cycles_dma(HDMA_CYCLES_PER_BLOCK);
                     }
-
-                    if self.dma.cycles_dma() > 0 {
-                        let cycles_dma = self.dma.cycles_dma().saturating_sub(cycles);
-                        self.dma.set_cycles_dma(cycles_dma);
-                        if cycles_dma == 0 {
-                            let count = 0x10.min(self.dma.pending());
-                            if self.mode == GameBoyMode::Cgb {
-                                let data = self.read_many(self.dma.source(), count);
-                                self.write_many(self.dma.destination(), &data);
-                            }
-                            self.dma.set_source(self.dma.source().wrapping_add(count));
-                            self.dma
-                                .set_destination(self.dma.destination().wrapping_add(count));
-                            self.dma
-                                .set_pending(self.dma.pending().saturating_sub(count));
-                            if self.dma.pending() == 0 {
-                                self.dma.set_active_hdma(false);
-                            }
-                        }
-                    }
+                } else {
+                    self.dma.set_cycles_dma(cycles_dma);
                 }
             }
         }
@@ -694,7 +683,7 @@ mod tests {
     };
 
     #[test]
-    fn test_hblank_hdma_transfer_timing() {
+    fn test_hdma_hblank_transfer_timing() {
         let mut mmu = Mmu::default();
         mmu.allocate_cgb();
         mmu.set_mode(GameBoyMode::Cgb);
@@ -726,6 +715,7 @@ mod tests {
         }
 
         // leaves HBlank mode and clocks the DMA to transfer the next 16 bytes
+        // this should not transfer any data as the PPU is not in HBlank mode
         mmu.ppu.clock(204);
         mmu.clock_dma(HDMA_CYCLES_PER_BLOCK);
         assert_eq!(mmu.dma.pending(), 0x10);
@@ -734,6 +724,51 @@ mod tests {
         // to transfer the next 16 bytes, making sure that all of
         // 32 bytes have been transferred
         mmu.ppu.clear_screen(false);
+        mmu.clock_dma(HDMA_CYCLES_PER_BLOCK);
+        assert_eq!(mmu.dma.pending(), 0x00);
+        for i in 0..0x20 {
+            assert_eq!(mmu.ppu.vram()[i as usize], i as u8);
+        }
+        assert!(!mmu.dma.active_hdma());
+    }
+
+    #[test]
+    fn test_hdma_general_transfer_timing() {
+        let mut mmu = Mmu::default();
+        mmu.allocate_cgb();
+        mmu.set_mode(GameBoyMode::Cgb);
+        mmu.ppu.set_gb_mode(GameBoyMode::Cgb);
+
+        // fills the RAM with data to be transferred (32 bytes)
+        for index in 0..0x20 {
+            mmu.write(0xc000 + index, index as u8);
+        }
+
+        mmu.dma.set_source(0xc000);
+        mmu.dma.set_destination(0x8000);
+        mmu.dma.set_length(0x20);
+        mmu.dma.set_pending(0x20);
+        mmu.dma.set_mode(DmaMode::General);
+        mmu.dma.set_active_hdma(true);
+
+        // initializes the PPU in HBlank mode
+        mmu.ppu.write(LCDC_ADDR, 0x80);
+        mmu.ppu.clear_screen(false);
+        assert!(mmu.ppu.vram()[0x0000..0x0020].iter().all(|&b| b == 0x0));
+
+        // clocks the DMA to transfer all 32 bytes at once
+        mmu.clock_dma(HDMA_CYCLES_PER_BLOCK);
+        assert_eq!(mmu.dma.pending(), 0x10);
+        for i in 0..0x10 {
+            assert_eq!(mmu.ppu.vram()[i as usize], i as u8);
+        }
+        assert!(mmu.dma.active_hdma());
+
+        // moves the PPU out of HBlank mode and clocks the DMA
+        // to transfer the next 16 bytes, making sure that all of
+        // 32 bytes have been transferred, for a general transfer
+        // it's irrelevant if the PPU is in HBlank mode or not
+        mmu.ppu.clock(204);
         mmu.clock_dma(HDMA_CYCLES_PER_BLOCK);
         assert_eq!(mmu.dma.pending(), 0x00);
         for i in 0..0x20 {

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -327,28 +327,28 @@ impl Mmu {
                     self.dma.set_pending(0);
                     self.dma.set_active_hdma(false);
                 }
-                DmaMode::HBlank => {
-                    if self.dma.mode() == DmaMode::HBlank && self.ppu.mode() == PpuMode::HBlank {
-                        let cycles_dma = self.dma.cycles_hdma().saturating_sub(cycles);
-                        if cycles_dma == 0x0 {
-                            let count = 0x10.min(self.dma.pending());
-                            if self.mode == GameBoyMode::Cgb {
-                                let data = self.read_many(self.dma.source(), count);
-                                self.write_many(self.dma.destination(), &data);
-                            }
-                            self.dma.set_source(self.dma.source().wrapping_add(count));
-                            self.dma
-                                .set_destination(self.dma.destination().wrapping_add(count));
-                            self.dma
-                                .set_pending(self.dma.pending().saturating_sub(count));
-                            if self.dma.pending() == 0x0 {
-                                self.dma.set_active_hdma(false);
-                            } else {
-                                self.dma.set_cycles_dma(HDMA_CYCLES_PER_BLOCK);
-                            }
-                        } else {
-                            self.dma.set_cycles_dma(cycles_dma);
+                DmaMode::HBlank
+                    if self.dma.mode() == DmaMode::HBlank && self.ppu.mode() == PpuMode::HBlank =>
+                {
+                    let cycles_dma = self.dma.cycles_hdma().saturating_sub(cycles);
+                    if cycles_dma == 0x0 {
+                        let count = 0x10.min(self.dma.pending());
+                        if self.mode == GameBoyMode::Cgb {
+                            let data = self.read_many(self.dma.source(), count);
+                            self.write_many(self.dma.destination(), &data);
                         }
+                        self.dma.set_source(self.dma.source().wrapping_add(count));
+                        self.dma
+                            .set_destination(self.dma.destination().wrapping_add(count));
+                        self.dma
+                            .set_pending(self.dma.pending().saturating_sub(count));
+                        if self.dma.pending() == 0x0 {
+                            self.dma.set_active_hdma(false);
+                        } else {
+                            self.dma.set_cycles_dma(HDMA_CYCLES_PER_BLOCK);
+                        }
+                    } else {
+                        self.dma.set_cycles_dma(cycles_dma);
                     }
                 }
             }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -327,9 +327,7 @@ impl Mmu {
                     self.dma.set_pending(0);
                     self.dma.set_active_hdma(false);
                 }
-                DmaMode::HBlank
-                    if self.dma.mode() == DmaMode::HBlank && self.ppu.mode() == PpuMode::HBlank =>
-                {
+                DmaMode::HBlank if self.ppu.mode() == PpuMode::HBlank => {
                     // in case the cycles value is 0xffff, it means that the
                     // HDMA transfer is just getting started, so we set the
                     // cycles to the `HDMA_CYCLES_PER_BLOCK`` value, this is done

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -338,6 +338,10 @@ impl Mmu {
                             .set_cycles_dma(HDMA_CYCLES_PER_BLOCK * self.speed.multiplier() as u16);
                     }
 
+                    // runs the HDMA transfer, this is done in blocks of 0x10 bytes
+                    // and the transfer is done in HBlank mode, so we can
+                    // transfer the data in blocks of 0x10 bytes, this is done
+                    // until the pending value is 0x0, at which point we stop
                     let cycles_dma = self.dma.cycles_hdma().saturating_sub(cycles);
                     if cycles_dma == 0x0 {
                         let count = 0x10.min(self.dma.pending());

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -823,6 +823,11 @@ impl Ppu {
         self.dmg_compat = false;
     }
 
+    /// Clears the screen and resets the PPU's mode, mode clock, LY registers
+    /// and VBlank interrupt flag.
+    ///
+    /// The optional `hard` parameter is used to clear the internal frame
+    /// buffer, considered to be an expensive operation.
     pub fn clear_screen(&mut self, hard: bool) {
         self.mode = PpuMode::HBlank;
         self.mode_clock = 0;


### PR DESCRIPTION
## Summary
- implement proper HBlank DMA transfers
- expose HDMA_CYCLES_PER_BLOCK constant
- enable HBlank DMA in MMU clock
- add unit test covering timing behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683ff1db20848328bba9144784fc3419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved HBlank DMA handling to accurately transfer data in 16-byte blocks during HBlank periods, aligning with expected timing behavior.
	- Added a screen clearing function with optional full frame buffer reset for better display control.
- **Bug Fixes**
	- Corrected bitmask usage for HDMA mode selection to ensure proper operation.
- **Tests**
	- Added tests to verify timing and correctness of HBlank DMA transfers.
	- Added tests for General DMA transfer timing and completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->