### PR TITLE
Optimize interrupt polling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,7 @@ harness = false
 [[bench]]
 name = "hashing"
 harness = false
+
+[[bench]]
+name = "cpu"
+harness = false

--- a/benches/cpu.rs
+++ b/benches/cpu.rs
@@ -1,0 +1,22 @@
+use boytacean::test::{build_test, TestOptions};
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn benchmark_cpu_clock(c: &mut Criterion) {
+    let mut gb = build_test(TestOptions {
+        ppu_enabled: Some(false),
+        apu_enabled: Some(false),
+        dma_enabled: Some(false),
+        timer_enabled: Some(false),
+        ..Default::default()
+    });
+    gb.load_rom_empty().unwrap();
+
+    c.bench_function("cpu_cycles", |b| {
+        b.iter(|| {
+            gb.clocks_cycles(1_000_000);
+        })
+    });
+}
+
+criterion_group!(benches, benchmark_cpu_clock);
+criterion_main!(benches);

--- a/benches/cpu.rs
+++ b/benches/cpu.rs
@@ -13,7 +13,7 @@ fn benchmark_cpu_clock(c: &mut Criterion) {
 
     c.bench_function("cpu_cycles", |b| {
         b.iter(|| {
-            gb.clocks_cycles(1_000_000);
+            gb.clocks_cycles(1000000);
         })
     });
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -162,9 +162,9 @@ impl Cpu {
             pc
         );
 
-        // Fetch the current interrupt request flags with the enabled mask
-        // applied. Each interrupt flag is fetched once so that both the
-        // halt release check and the handler dispatch reuse the value.
+        // fetch the current interrupt request flags with the enabled mask
+        // applied, each interrupt flag is fetched once so that both the
+        // halt release check and the handler dispatch reuse the value
         let flags = (self.mmu.ppu().int_vblank() as u8)
             | ((self.mmu.ppu().int_stat() as u8) << 1)
             | ((self.mmu.timer().int_tima() as u8) << 2)

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -47,11 +47,17 @@ pub struct Cpu {
     pub h: u8,
     pub l: u8,
 
+    /// Interrupt Master Enable (IME) flag, indicates if the CPU is
+    /// currently allowing interrupts to be serviced.
     ime: bool,
+
     zero: bool,
     sub: bool,
     half_carry: bool,
     carry: bool,
+
+    /// Indicates if the CPU is currently halted, waiting for an
+    /// interrupt to be serviced.
     halted: bool,
 
     /// Reference to the MMU (Memory Management Unit) to be used
@@ -172,9 +178,10 @@ impl Cpu {
             | ((self.mmu.pad().int_pad() as u8) << 4);
         let pending = flags & self.mmu.ie;
 
-        // in case the CPU execution halted and there's a pending interrupt
-        // while IME is disabled, release the CPU from the halted state so
-        // execution can continue until the interrupt is serviced
+        // in case the CPU execution is halted and there's a pending interrupt
+        // while IME is disabled, releases the CPU from the halted state so that
+        // execution can continue until the interrupt is serviced, this prevents
+        // the CPU from getting stuck in the halted state
         if self.halted && !self.ime && pending != 0 {
             self.halted = false;
         }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -300,7 +300,10 @@ impl Cpu {
         // (Program Counter) according to the final value returned
         // by the fetch operation (we may need to fetch instruction
         // more than one byte of length)
-        let (inst, pc) = self.fetch(self.pc);
+        #[cfg(feature = "cpulog")]
+        let (inst, pc, opcode, is_prefix) = self.fetch(self.pc);
+        #[cfg(not(feature = "cpulog"))]
+        let (inst, pc, _, _) = self.fetch(self.pc);
         self.ppc = self.pc;
         self.pc = pc;
 
@@ -339,7 +342,7 @@ impl Cpu {
     }
 
     #[inline(always)]
-    fn fetch(&self, pc: u16) -> (Instruction, u16) {
+    fn fetch(&self, pc: u16) -> (Instruction, u16, u8, bool) {
         let mut pc = pc;
 
         // fetches the current instruction and increments
@@ -360,9 +363,11 @@ impl Cpu {
             inst = &INSTRUCTIONS[opcode as usize];
         }
 
-        // returns both the fetched instruction and the
-        // updated PC (Program Counter) value
-        (inst, pc)
+        // returns both the fetched instruction, the updated
+        // PC (Program Counter) value, the resolved opcode
+        // and the flag that indicates if the instruction is
+        //a prefix instruction
+        (inst, pc, opcode, is_prefix)
     }
 
     #[inline(always)]
@@ -666,7 +671,7 @@ impl Cpu {
     }
 
     pub fn description_default(&self) -> String {
-        let (inst, _) = self.fetch(self.ppc);
+        let (inst, _, _, _) = self.fetch(self.ppc);
         self.description(inst, self.ppc)
     }
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -740,6 +740,8 @@ mod tests {
 
     use super::Cpu;
 
+    /// Tests that the CPU is able to execute instructions and
+    /// that the state is updated correctly.
     #[test]
     fn test_cpu_clock() {
         let mut cpu = Cpu::default();
@@ -871,6 +873,7 @@ mod tests {
         assert_eq!(cpu.a, 0x0a ^ 0x0f);
     }
 
+    /// Tests that the CPU is able to save and restore its state.
     #[test]
     fn test_state_and_set_state() {
         let cpu = Cpu {
@@ -920,15 +923,16 @@ mod tests {
         assert_eq!(new_cpu.ppc, 0x9abc);
     }
 
+    /// Tests that the CPU ignores interrupts when IME is disabled.
     #[test]
-    fn test_interrupt_ignored_when_ime_disabled() {
+    fn test_int_ignored_ime_disabled() {
         let mut cpu = Cpu::default();
         cpu.boot();
         cpu.mmu.allocate_default();
 
         cpu.pc = 0xc000;
         cpu.sp = 0xfffe;
-        cpu.mmu.write(0xc000, 0x00); // NOP
+        cpu.mmu.write(0xc000, 0x00);
         cpu.mmu.ie = 0x01;
         cpu.mmu.ppu().set_int_vblank(true);
         cpu.disable_int();
@@ -940,15 +944,17 @@ mod tests {
         assert!(cpu.mmu.ppu().int_vblank());
     }
 
+    /// Tests that the CPU is able to handle interrupts
+    /// when IME is enabled.
     #[test]
-    fn test_interrupt_handled_when_ime_enabled() {
+    fn test_int_handled_ime_enabled() {
         let mut cpu = Cpu::default();
         cpu.boot();
         cpu.mmu.allocate_default();
 
         cpu.pc = 0xc000;
         cpu.sp = 0xfffe;
-        cpu.mmu.write(0xc000, 0x00); // NOP
+        cpu.mmu.write(0xc000, 0x00);
         cpu.mmu.ie = 0x01;
         cpu.mmu.ppu().set_int_vblank(true);
         cpu.enable_int();
@@ -963,15 +969,17 @@ mod tests {
         assert_eq!(cpu.mmu.read(0xfffd), 0xc0);
     }
 
+    /// Tests that the CPU is released from the halted state when an
+    /// interrupt is pending, even when IME is disabled.
     #[test]
-    fn test_halt_released_on_pending_interrupt() {
+    fn test_halt_released_on_pending_int() {
         let mut cpu = Cpu::default();
         cpu.boot();
         cpu.mmu.allocate_default();
 
         cpu.pc = 0xc000;
         cpu.sp = 0xfffe;
-        cpu.mmu.write(0xc000, 0x00); // NOP
+        cpu.mmu.write(0xc000, 0x00);
         cpu.mmu.ie = 0x01;
         cpu.mmu.ppu().set_int_vblank(true);
         cpu.disable_int();

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -1430,6 +1430,8 @@ impl GameBoy {
         }
     }
 
+    /// Loads an empty ROM into the Game Boy, this is useful for
+    /// testing the CPU and other Game Boy components without a ROM.
     pub fn load_rom_empty(&mut self) -> Result<&mut Cartridge, Error> {
         let data = [0u8; 32 * 1024];
         self.load_rom(&data, None)


### PR DESCRIPTION
## Summary
- clean up halt release comment and remove TODO
- prefetch interrupt flags and reuse for halt and handler checks
- use pending flags to branch on interrupts instead of multiple MMU calls

## Testing
- `cargo bench --bench cpu --quiet` before change: ~1.86 ms
- `cargo bench --bench cpu --quiet` after change: ~1.90 ms

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684086e0bca883289b871c522e3a259e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new CPU benchmarking tool to measure CPU cycle performance.

- **Refactor**
  - Improved and simplified CPU interrupt handling logic for better efficiency and clarity.

- **Tests**
  - Introduced unit tests to verify interrupt handling and CPU halt state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->