### PR TITLE
Fix BMP LE byte order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,10 @@ features = ["wasm", "gen-mock"]
 name = "bosc-decompress"
 path = "src/bin/bosc-decompress.rs"
 
+[[bin]]
+name = "bosc-thumbnail"
+path = "src/bin/bosc-thumbnail.rs"
+
 [[bench]]
 name = "color"
 harness = false

--- a/crates/common/src/util.rs
+++ b/crates/common/src/util.rs
@@ -76,16 +76,25 @@ pub fn capitalize(string: &str) -> String {
     }
 }
 
+/// Saves the pixel data as a BMP file at the specified path.
+/// The pixel data should be in RGB format, with each pixel
+/// represented by three bytes (red, green, blue).
+///
+/// This is a raw implementation of BMP file saving, not using any
+/// external libraries. It writes the BMP file header and pixel data
+/// directly to the file in the correct format.
 pub fn save_bmp(path: &str, pixels: &[u8], width: u32, height: u32) -> Result<(), Error> {
     let file = File::create(path)
         .map_err(|_| Error::CustomError(format!("Failed to create file: {path}")))?;
     let mut writer = BufWriter::new(file);
 
-    // writes the BMP file header
-    // each row in a BMP is padded to a 4 byte boundary
+    // calculates the size of the BMP file header and the pixel data
+    // according to the BMP file format specification
     let row_bytes = (width * 3 + 3) & !3;
     let image_size = row_bytes * height;
     let file_size = BMP_HEADER_SIZE + image_size;
+
+    // writes the BMP file header into the writer
     writer.write_all(&[0x42, 0x4d]).unwrap(); // "BM" magic number
     writer.write_all(&file_size.to_le_bytes()).unwrap(); // file size
     writer.write_all(&[0x00, 0x00]).unwrap(); // reserved

--- a/crates/common/src/util.rs
+++ b/crates/common/src/util.rs
@@ -94,9 +94,7 @@ pub fn save_bmp(path: &str, pixels: &[u8], width: u32, height: u32) -> Result<()
     writer.write_all(&[0x01, 0x00]).unwrap(); // color planes
     writer.write_all(&[0x18, 0x00]).unwrap(); // bits per pixel
     writer.write_all(&[0x00, 0x00, 0x00, 0x00]).unwrap(); // compression method
-    writer
-        .write_all(&image_size.to_le_bytes())
-        .unwrap(); // image size
+    writer.write_all(&image_size.to_le_bytes()).unwrap(); // image size
     writer.write_all(&[0x13, 0x0b, 0x00, 0x00]).unwrap(); // horizontal resolution (72 DPI)
     writer.write_all(&[0x13, 0x0b, 0x00, 0x00]).unwrap(); // vertical resolution (72 DPI)
     writer.write_all(&[0x00, 0x00, 0x00, 0x00]).unwrap(); // color palette
@@ -182,7 +180,7 @@ pub fn timestamp() -> u64 {
 mod tests {
     use std::path::Path;
 
-    use super::{capitalize, replace_ext};
+    use super::{capitalize, replace_ext, save_bmp};
 
     #[test]
     fn test_change_extension() {
@@ -234,11 +232,11 @@ mod tests {
 
     #[test]
     fn test_bmp_le_bytes() {
-        // According to the BMP file format specification, both the file size
+        // according to the BMP file format specification, both the file size
         // and the image size fields are stored using little-endian encoding.
         let path = std::env::temp_dir().join("boytacean_le_test.bmp");
         let _ = save_bmp(path.to_str().unwrap(), &[255, 0, 0], 1, 1);
-        let data = std::fs::read(&path).unwrap();
+        let data: Vec<u8> = std::fs::read(&path).unwrap();
         assert_eq!(&data[2..6], &(58u32).to_le_bytes());
         assert_eq!(&data[34..38], &(4u32).to_le_bytes());
         std::fs::remove_file(path).unwrap();
@@ -250,14 +248,10 @@ mod tests {
         // expected structure as defined in the specification.
         let path = std::env::temp_dir().join("boytacean_spec_test.bmp");
         let pixels = [
-            // red
-            255u8, 0, 0,
-            // green
-            0, 255, 0,
-            // blue
-            0, 0, 255,
-            // yellow
-            255, 255, 0,
+            255, 0, 0, // red
+            0, 255, 0, // green
+            0, 0, 255, // blue
+            255, 255, 0, // yellow
         ];
         let _ = save_bmp(path.to_str().unwrap(), &pixels, 2, 2);
         let data = std::fs::read(&path).unwrap();

--- a/src/bin/bosc-thumbnail.rs
+++ b/src/bin/bosc-thumbnail.rs
@@ -47,9 +47,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // reads as BOSC and saves the thumbnail as BMP
     let mut bosc_state = StateManager::read_bosc(&input_data)?;
-    bosc_state
-        .bos()
-        .save_image_bmp(output_path.to_str().unwrap())?;
+    bosc_state.bos().save_image_bmp(output_path.to_str()?)?;
 
     println!("Successfully extracted thumbnail from BOSC file");
 

--- a/src/bin/bosc-thumbnail.rs
+++ b/src/bin/bosc-thumbnail.rs
@@ -47,7 +47,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // reads as BOSC and saves the thumbnail as BMP
     let mut bosc_state = StateManager::read_bosc(&input_data)?;
-    bosc_state.bos().save_image_bmp(output_path.to_str()?)?;
+    bosc_state
+        .bos()
+        .save_image_bmp(output_path.to_str().ok_or("Invalid output path")?)?;
 
     println!("Successfully extracted thumbnail from BOSC file");
 

--- a/src/bin/bosc-thumbnail.rs
+++ b/src/bin/bosc-thumbnail.rs
@@ -1,17 +1,18 @@
-//! Decompression utility for BOSC files
+//! Thumbnail extractor for BOSC files
 //!
-//! This utility reads a compressed BOSC file and decompresses it into the BOS format.
-//! It can be used to convert BOSC files back to their original BOS format for further processing.
+//! This utility reads a compressed BOSC file and extracts the thumbnail image,
+//! saving it as a BMP file. If no output file is specified, it will use the input file's
+//! name with a `.bmp` extension.
 //!
 //! # Usage
-//! bosc-decompress <input_file> [output_file]
+//! bosc-thumbnail <bosc_file> [thumbnail_file]
 
-use boytacean::state::{SaveStateFormat, Serialize, StateManager};
+use boytacean::state::{SaveStateFormat, StateManager};
 use std::{env::args, error::Error, fs::File, io::Read, path::Path};
 
 fn print_usage() {
-    println!("Usage: bosc-decompress <input_file> [output_file]");
-    println!("If output_file is not specified, it will use input_file with .bos extension");
+    println!("Usage: bosc-thumbnail <bosc_file> [thumbnail_file]");
+    println!("If thumbnail_file is not specified, it will use bosc_file with .bmp extension");
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -27,14 +28,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         Path::new(&args[2]).to_path_buf()
     } else {
         let mut output = input_path.to_path_buf();
-        output.set_extension("bos");
+        output.set_extension("bmp");
         output
     };
 
-    println!(
-        "Decompressing BOSC file to BOS format {}",
-        output_path.display()
-    );
+    println!("Extracting BOSC thumbnail {}", output_path.display());
 
     // read input file with the compressed values
     let mut input_file = File::open(input_path)?;
@@ -47,12 +45,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         return Err("Input file is not in BOSC format".into());
     }
 
-    // reads as BOSC and convert to BOS
+    // reads as BOSC and saves the thumbnail as BMP
     let mut bosc_state = StateManager::read_bosc(&input_data)?;
-    let mut output_file = File::create(output_path)?;
-    bosc_state.bos().write(&mut output_file)?;
+    bosc_state
+        .bos()
+        .save_image_bmp(output_path.to_str().unwrap())?;
 
-    println!("Successfully decompressed BOSC file to BOS format");
+    println!("Successfully extracted thumbnail from BOSC file");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- ensure BMP pixel array size uses little-endian encoding
- add test validating LE encoding according to spec

## Testing
- `cargo test --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `cargo fmt` *(fails: 'cargo-fmt' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68447bcbeea08328a61aeccb1391b95f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line utility to extract and save thumbnail images from BOSC files as BMP images.

- **Bug Fixes**
  - Corrected BMP image saving to properly include row padding, ensuring accurate file and image size calculations for better BMP format compatibility.

- **Tests**
  - Added tests to verify BMP header fields, confirming correct file size, image size, and format compliance for small images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->