### PR TITLE
Fix ROM title extraction

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -1483,12 +1483,10 @@ impl BessInfo {
                 break;
             }
         }
-        String::from(
-            String::from_utf8(Vec::from(&self.title[..final_index]))
-                .unwrap()
-                .trim_matches(char::from(0))
-                .trim(),
-        )
+        String::from_utf8_lossy(&self.title[..final_index])
+            .trim_matches('\0')
+            .trim()
+            .to_string()
     }
 }
 


### PR DESCRIPTION
## Summary
- fix parsing of ROM title by using `String::from_utf8_lossy` and removing extra `String::from`
- inline usage of ROM title slice

## Testing
- `cargo fmt --all` *(failed: rustfmt missing)*
- `cargo test state -- --nocapture` *(failed to run tests offline)*

------
https://chatgpt.com/codex/tasks/task_e_68447ca36edc83288e8cd92383a9762e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid characters in displayed titles to prevent potential errors and ensure smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->