### PR TITLE
Implement SDL caching in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,6 +141,16 @@ jobs:
           rustup component add clippy
       - name: Print Rust information
         run: rustc --version
+      - name: Cache SDL build
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.vcpkg-root
+            ~/.cache/vcpkg
+            ~/vcpkg
+          key: vcpkg-${{ runner.os }}-${{ hashFiles('frontends/sdl/Cargo.toml') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-
       - name: Install SDL dependencies
         run: cd frontends/sdl && cargo install cargo-vcpkg && cargo vcpkg -v build
       - name: Verify Rust code format


### PR DESCRIPTION
## Summary
- cache SDL build outputs using actions/cache in `main.yml`
- revert caching changes from `deploy.yml` and `extra.yml`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68449fd1c2d883289dcb500367ad3cc4