### PR TITLE
Improve agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,28 @@
-# Agents.md file
+# Development Guide
 
-This document serves as the main reference for the agent's configuration, usage, and development notes. Please refer to the sections below for detailed instructions and guidelines.
+This document describes how to work with the project. Follow these notes when writing code or submitting pull requests.
+
+## Setup
+
+Install Python packages and the Rust toolchain:
+
+```bash
+pip install -r requirements.txt
+rustup default stable
+```
 
 ## Formatting
 
-Always format the code before commiting using, making sure that the Rust code is properly formatted using:
+Format all code before committing:
 
 ```bash
 cargo fmt --all
-```
-
-For the Python code, use:
-
-```bash
 black .
 ```
 
 ## Testing
 
-Always run the tests before committing changes to ensure that everything is working as expected. Use the following commands:
+Run the full test suite:
 
 ```bash
 cargo test --all
@@ -26,15 +30,8 @@ cargo test --all
 
 ## Style Guide
 
-### Changelog
-
-It's important to keep track of changes made to the codebase. Use proper semantic versioning and document changes in the `CHANGELOG.md` file.
-
-### Commit Messages
-
-When committing changes, use clear and descriptive commit messages that explain the purpose of the changes. The commit messages should be concise yet informative, providing context for future reference.
-
-Also the commit messages should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard to ensure clarity and consistency.
+- Update `CHANGELOG.md` according to semantic versioning.
+- Write commit messages using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ## License
 


### PR DESCRIPTION
## Summary
- clarify instructions in `AGENTS.md`
- add setup and formatting details

## Testing
- `cargo fmt --all`
- `black .`
- `cargo test --all` *(fails: VcpkgNotFound)*

------
https://chatgpt.com/codex/tasks/task_e_684761bd376c8328a5d77e5293dd84f0