### PR TITLE
Add network serial device for netplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *
 
+## [0.11.6] - 2025-03-20
+
+### Added
+
+* Experimental network serial device for basic netplay
+
 ### Changed
 
 * Added support for HBlank HDMA transfers

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "boytacean"
 description = "A Game Boy emulator that is written in Rust."
-version = "0.11.5"
+version = "0.11.6"
 authors = ["João Magalhães <joamag@gmail.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/joamag/boytacean"
@@ -26,9 +26,9 @@ cpulog = []
 gen-mock = []
 
 [dependencies]
-boytacean-common = { path = "crates/common", version = "0.11.5" }
-boytacean-encoding = { path = "crates/encoding", version = "0.11.5" }
-boytacean-hashing = { path = "crates/hashing", version = "0.11.5" }
+boytacean-common = { path = "crates/common", version = "0.11.6" }
+boytacean-encoding = { path = "crates/encoding", version = "0.11.6" }
+boytacean-hashing = { path = "crates/hashing", version = "0.11.6" }
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true }
 pyo3 = { version = "0.20", optional = true }
@@ -69,7 +69,7 @@ members = [
     "crates/encoding",
     "crates/hashing"
 ]
-package = { version = "0.11.5", authors = ["João Magalhães <joamag@gmail.com>"], edition = "2021", rust-version = "1.82" }
+package = { version = "0.11.6", authors = ["João Magalhães <joamag@gmail.com>"], edition = "2021", rust-version = "1.82" }
 
 [package.metadata.docs.rs]
 features = ["wasm", "gen-mock"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Game Boy emulator that is written in Rust 🦀.
 * Web, [SDL](https://www.libsdl.org) and [Libretro](https://www.libretro.com) front-ends
 * Audio, with a pretty accurate APU
 * Serial Data Transfer ([Link Cable](https://en.wikipedia.org/wiki/Game_Link_Cable)) support
+* Experimental network link cable for basic netplay
 * [Game Boy Printer](https://en.wikipedia.org/wiki/Game_Boy_Printer) emulation
 * Support for multiple MBCs: MBC1, MBC2, MBC3, and MBC5
 * Save state support using the [BESS Specification](https://github.com/LIJI32/SameBoy/blob/master/BESS.md) for cross-compatibility with other emulators

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "boytacean-common"
 description = "Commons library for Boytacen."
-version = "0.11.5"
+version = "0.11.6"
 authors = ["João Magalhães <joamag@gmail.com>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "boytacean-encoding"
 description = "Codecs library for Boytacen."
-version = "0.11.5"
+version = "0.11.6"
 authors = ["João Magalhães <joamag@gmail.com>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -11,8 +11,8 @@ rust-version = "1.82"
 simd = ["boytacean-hashing/simd"]
 
 [dependencies]
-boytacean-common = { path = "../common", version = "0.11.5" }
-boytacean-hashing = { path = "../hashing", version = "0.11.5" }
+boytacean-common = { path = "../common", version = "0.11.6" }
+boytacean-hashing = { path = "../hashing", version = "0.11.6" }
 
 [[bin]]
 name = "zippy"

--- a/crates/hashing/Cargo.toml
+++ b/crates/hashing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "boytacean-hashing"
 description = "Hashing library for Boytacen."
-version = "0.11.5"
+version = "0.11.6"
 authors = ["João Magalhães <joamag@gmail.com>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -11,4 +11,4 @@ rust-version = "1.82"
 simd = []
 
 [dependencies]
-boytacean-common = { path = "../common", version = "0.11.5" }
+boytacean-common = { path = "../common", version = "0.11.6" }

--- a/frontends/console/Cargo.toml
+++ b/frontends/console/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boytacean-console"
-version = "0.11.5"
+version = "0.11.6"
 authors = ["João Magalhães <joamag@gmail.com>"]
 description = "A Console frontend for Boytacen"
 license = "Apache-2.0"
@@ -16,4 +16,4 @@ pedantic = ["boytacean/pedantic"]
 cpulog = ["boytacean/cpulog"]
 
 [dependencies]
-boytacean = { path = "../..", version = "0.11.5" }
+boytacean = { path = "../..", version = "0.11.6" }

--- a/frontends/libretro/Cargo.toml
+++ b/frontends/libretro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boytacean-libretro"
-version = "0.11.5"
+version = "0.11.6"
 authors = ["João Magalhães <joamag@gmail.com>"]
 description = "A Libretro frontend for Boytacen"
 license = "Apache-2.0"
@@ -18,4 +18,4 @@ pedantic = ["boytacean/pedantic"]
 cpulog = ["boytacean/cpulog"]
 
 [dependencies]
-boytacean = { path = "../..", version = "0.11.5" }
+boytacean = { path = "../..", version = "0.11.6" }

--- a/frontends/libretro/res/boytacean_libretro.info
+++ b/frontends/libretro/res/boytacean_libretro.info
@@ -6,7 +6,7 @@ corename = "Boytacean"
 categories = "Emulator"
 license = "Apache-2."
 permissions = ""
-display_version = "0.11.5"
+display_version = "0.11.6"
 
 # Hardware Information
 manufacturer = "Nintendo"

--- a/frontends/sdl/Cargo.toml
+++ b/frontends/sdl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boytacean-sdl"
-version = "0.11.5"
+version = "0.11.6"
 authors = ["João Magalhães <joamag@gmail.com>"]
 description = "An SDL frontend for Boytacen"
 license = "Apache-2.0"
@@ -16,8 +16,8 @@ pedantic = ["boytacean/pedantic"]
 cpulog = ["boytacean/cpulog"]
 
 [dependencies]
-boytacean = { path = "../..", version = "0.11.5" }
-boytacean-common = { path = "../../crates/common", version = "0.11.5" }
+boytacean = { path = "../..", version = "0.11.6" }
+boytacean-common = { path = "../../crates/common", version = "0.11.6" }
 clap = { version = "4", features = ["derive"] }
 image = "0.24"
 chrono = "0.4"

--- a/frontends/sdl/README.md
+++ b/frontends/sdl/README.md
@@ -99,6 +99,15 @@ It's possible to run the emulator in headless mode using the `--headless` parame
 cargo run -- --rom-path ../../res/roms/test/blargg/cpu/cpu_instrs.gb --cycles 100000000 --headless --device stdout --unlimited
 ```
 
+### Network play
+
+Two emulator instances can be connected through a TCP socket to emulate the link cable:
+
+```bash
+cargo run -- --rom-path game.gb --device net-listen:127.0.0.1:6000
+cargo run -- --rom-path game.gb --device net:127.0.0.1:6000
+```
+
 ## Features
 
 | Provider   | Description                                                                                                                                |

--- a/frontends/sdl/src/main.rs
+++ b/frontends/sdl/src/main.rs
@@ -5,7 +5,7 @@ pub mod test;
 
 use audio::Audio;
 use boytacean::{
-    devices::{printer::PrinterDevice, stdout::StdoutDevice},
+    devices::{network::NetworkDevice, printer::PrinterDevice, stdout::StdoutDevice},
     gb::{AudioProvider, GameBoy, GameBoyMode},
     info::Info,
     pad::PadKey,
@@ -1097,6 +1097,14 @@ fn build_device(device: &str) -> Result<Box<dyn SerialDevice>, Error> {
                 .unwrap();
             });
             Ok(printer)
+        }
+        device if device.starts_with("net-listen:") => {
+            let addr = &device[11..];
+            Ok(Box::new(NetworkDevice::listen(addr)?))
+        }
+        device if device.starts_with("net:") => {
+            let addr = &device[4..];
+            Ok(Box::new(NetworkDevice::connect(addr)?))
         }
         _ => Err(Error::InvalidParameter(format!(
             "Unsupported device: {device}"

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "boytacean-web",
-    "version": "0.11.5",
+    "version": "0.11.6",
     "description": "The web version of Boytacean",
     "repository": {
         "type": "git",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ except ImportError:
 
 setuptools.setup(
     name="boytacean",
-    version="0.11.5",
+    version="0.11.6",
     author="João Magalhães",
     author_email="joamag@gmail.com",
     description="A Game Boy emulator that is written in Rust",

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -5,5 +5,6 @@
 //! to the Game Boy (eg: [`printer`]).
 
 pub mod buffer;
+pub mod network;
 pub mod printer;
 pub mod stdout;

--- a/src/devices/network.rs
+++ b/src/devices/network.rs
@@ -1,0 +1,65 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+};
+
+use boytacean_common::error::Error;
+
+use crate::serial::SerialDevice;
+
+pub enum NetworkMode {
+    Client,
+    Server,
+}
+
+pub struct NetworkDevice {
+    stream: TcpStream,
+}
+
+impl NetworkDevice {
+    pub fn connect(addr: &str) -> Result<Self, Error> {
+        let stream = TcpStream::connect(addr)?;
+        stream.set_nonblocking(true)?;
+        Ok(Self { stream })
+    }
+
+    pub fn listen(addr: &str) -> Result<Self, Error> {
+        let listener = TcpListener::bind(addr)?;
+        let (stream, _) = listener.accept()?;
+        stream.set_nonblocking(true)?;
+        Ok(Self { stream })
+    }
+}
+
+impl SerialDevice for NetworkDevice {
+    fn send(&mut self) -> u8 {
+        let mut buffer = [0u8; 1];
+        match self.stream.read_exact(&mut buffer) {
+            Ok(_) => buffer[0],
+            Err(_) => 0xff,
+        }
+    }
+
+    fn receive(&mut self, byte: u8) {
+        let _ = self.stream.write_all(&[byte]);
+    }
+
+    fn allow_slave(&self) -> bool {
+        true
+    }
+
+    fn description(&self) -> String {
+        String::from("Network")
+    }
+
+    fn state(&self) -> String {
+        String::from("")
+    }
+}
+
+impl Display for NetworkDevice {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "Network")
+    }
+}


### PR DESCRIPTION
## Summary
- implement `NetworkDevice` for serial over TCP
- enable network device in SDL frontend
- document netplay options in README
- bump version to 0.11.6

## Testing
- `cargo fmt --all`
- `black .`
- `cargo test --all` *(fails: VcpkgNotFound)*

------
https://chatgpt.com/codex/tasks/task_e_6847618152d48328a31b1900f5455403