### PR TITLE
Add optional high-pass filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* High-pass audio filter options (Preserve, Accurate, Disable)
+* High-pass audio filter options (Preserve, Accurate, Disable) with save-state support
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Added support for HBlank HDMA transfers
-* Audio samples are now exported as signed 16-bit values
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Added support for HBlank HDMA transfers
+* Audio samples are now exported as signed 16-bit values
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* High-pass audio filter options (Preserve, Accurate, Disable)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Game Boy emulator that is written in Rust 🦀.
 * Simple navigable source-code
 * Web, [SDL](https://www.libsdl.org) and [Libretro](https://www.libretro.com) front-ends
 * Audio, with a pretty accurate APU
+* Optional high-pass audio filter (Preserve, Accurate or Disabled)
 * Serial Data Transfer ([Link Cable](https://en.wikipedia.org/wiki/Game_Link_Cable)) support
 * [Game Boy Printer](https://en.wikipedia.org/wiki/Game_Boy_Printer) emulation
 * Support for multiple MBCs: MBC1, MBC2, MBC3, and MBC5

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Game Boy emulator that is written in Rust 🦀.
 * Game Boy (DMG) and Game Boy Color (CGB) emulation
 * Simple navigable source-code
 * Web, [SDL](https://www.libsdl.org) and [Libretro](https://www.libretro.com) front-ends
-* Audio, with a pretty accurate APU producing 16-bit samples
+* Audio, with a pretty accurate APU
 * Optional high-pass audio filter (Preserve, Accurate or Disabled)
 * Serial Data Transfer ([Link Cable](https://en.wikipedia.org/wiki/Game_Link_Cable)) support
 * [Game Boy Printer](https://en.wikipedia.org/wiki/Game_Boy_Printer) emulation

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Game Boy emulator that is written in Rust 🦀.
 * Game Boy (DMG) and Game Boy Color (CGB) emulation
 * Simple navigable source-code
 * Web, [SDL](https://www.libsdl.org) and [Libretro](https://www.libretro.com) front-ends
-* Audio, with a pretty accurate APU
+* Audio, with a pretty accurate APU producing 16-bit samples
 * Optional high-pass audio filter (Preserve, Accurate or Disabled)
 * Serial Data Transfer ([Link Cable](https://en.wikipedia.org/wiki/Game_Link_Cable)) support
 * [Game Boy Printer](https://en.wikipedia.org/wiki/Game_Boy_Printer) emulation

--- a/crates/common/src/data.rs
+++ b/crates/common/src/data.rs
@@ -62,6 +62,13 @@ pub fn read_i64<R: Read>(reader: &mut R) -> Result<i64, Error> {
 }
 
 #[inline(always)]
+pub fn read_f32<R: Read>(reader: &mut R) -> Result<f32, Error> {
+    let mut buffer = [0x00; size_of::<f32>()];
+    reader.read_exact(&mut buffer)?;
+    Ok(f32::from_le_bytes(buffer))
+}
+
+#[inline(always)]
 pub fn read_bytes<R: Read>(reader: &mut R, count: usize) -> Result<Vec<u8>, Error> {
     let mut buffer = vec![0; count];
     reader.read_exact(&mut buffer)?;
@@ -124,6 +131,12 @@ pub fn write_u64<W: Write>(writer: &mut W, value: u64) -> Result<(), Error> {
 
 #[inline(always)]
 pub fn write_i64<W: Write>(writer: &mut W, value: i64) -> Result<(), Error> {
+    writer.write_all(&value.to_le_bytes())?;
+    Ok(())
+}
+
+#[inline(always)]
+pub fn write_f32<W: Write>(writer: &mut W, value: f32) -> Result<(), Error> {
     writer.write_all(&value.to_le_bytes())?;
     Ok(())
 }

--- a/frontends/libretro/src/core.rs
+++ b/frontends/libretro/src/core.rs
@@ -340,7 +340,7 @@ pub extern "C" fn retro_run() {
         let audio_buffer = emulator
             .audio_buffer()
             .iter()
-            .copied()
+            .map(|v| *v as i16 * 256)
             .collect::<Vec<i16>>();
         sample_batch_cb(audio_buffer.as_ptr(), audio_buffer.len() / 2_usize);
         emulator.clear_audio_buffer();

--- a/frontends/libretro/src/core.rs
+++ b/frontends/libretro/src/core.rs
@@ -340,7 +340,7 @@ pub extern "C" fn retro_run() {
         let audio_buffer = emulator
             .audio_buffer()
             .iter()
-            .map(|v| *v as i16 * 256)
+            .copied()
             .collect::<Vec<i16>>();
         sample_batch_cb(audio_buffer.as_ptr(), audio_buffer.len() / 2_usize);
         emulator.clear_audio_buffer();

--- a/frontends/sdl/src/main.rs
+++ b/frontends/sdl/src/main.rs
@@ -42,7 +42,7 @@ const SCREEN_SCALE: f32 = 3.0;
 
 /// Base audio volume to be used as the basis of the
 /// amplification level of the volume
-const VOLUME: f32 = 64.0;
+const VOLUME: f32 = 32768.0;
 
 /// The rate (in seconds) at which the current battery
 /// backed RAM is going to be stored into the file system.

--- a/frontends/sdl/src/main.rs
+++ b/frontends/sdl/src/main.rs
@@ -42,7 +42,7 @@ const SCREEN_SCALE: f32 = 3.0;
 
 /// Base audio volume to be used as the basis of the
 /// amplification level of the volume
-const VOLUME: f32 = 32768.0;
+const VOLUME: f32 = 64.0;
 
 /// The rate (in seconds) at which the current battery
 /// backed RAM is going to be stored into the file system.

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -795,9 +795,9 @@ impl Apu {
             HighPassFilter::Preserve => {
                 let output = input - self.filter_diff[channel];
                 let volume_bits = if channel == 0 {
-                    (self.master & 0x07) as f32
-                } else {
                     ((self.master >> 4) & 0x07) as f32
+                } else {
+                    (self.master & 0x07) as f32
                 };
                 let volume = (volume_bits + 1.0) * 15.0;
                 self.filter_diff[channel] = volume * (1.0 - self.filter_rate)

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -176,7 +176,7 @@ pub struct Apu {
 
     /// The audio buffer that is used to store the audio
     /// samples that are going to be outputted, uses an
-    /// integer deque to store the audio samples.
+    /// integer (i16) deque to store the audio samples.
     audio_buffer: VecDeque<i16>,
     audio_buffer_max: usize,
 

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -66,9 +66,9 @@ impl From<u8> for HighPassFilter {
     }
 }
 
-impl Into<u8> for HighPassFilter {
-    fn into(self) -> u8 {
-        match self {
+impl From<HighPassFilter> for u8 {
+    fn from(val: HighPassFilter) -> Self {
+        match val {
             HighPassFilter::Disable => 1,
             HighPassFilter::Preserve => 2,
             HighPassFilter::Accurate => 3,

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -807,6 +807,14 @@ impl Apu {
         }
     }
 
+    /// Returns the current output of the APU, this is the sum
+    /// of the outputs of all channels, this is used to
+    /// calculate the final audio output that is going to be
+    /// sent to the audio buffer.
+    /// 
+    /// This value is not filtered, it is the raw output
+    /// of the channels, the filtering is done in the `filter_sample`
+    /// method, which is called when the audio sample is created.
     #[inline(always)]
     pub fn output(&self) -> u16 {
         self.ch1_output() as u16
@@ -815,6 +823,12 @@ impl Apu {
             + self.ch4_output() as u16
     }
 
+    /// Filters the given sample based on the current filter mode
+    /// and returns the filtered sample as an i16 value.
+    /// 
+    /// The `channel` parameter is used to determine which channel
+    /// the sample belongs to, this is used to apply the correct
+    /// filtering based on the channel's configuration.
     #[inline(always)]
     fn filter_sample(&mut self, sample: u16, channel: usize) -> i16 {
         match self.filter_mode {

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -1696,7 +1696,7 @@ mod tests {
         assert_eq!(new_apu.sequencer, 12345);
         assert_eq!(new_apu.sequencer_step, 6);
         assert_eq!(new_apu.output_timer, 789);
-        assert_eq!(new_apu.filter_mode as u8, 2);
+        assert_eq!(new_apu.filter_mode as u8, 1);
     }
 
     #[test]
@@ -1705,6 +1705,17 @@ mod tests {
         let sample = 128;
         let value = apu.filter_sample(sample, 0);
         assert_eq!(value, sample as i16);
+    }
+
+    #[test]
+    fn test_filter_sample_accurate() {
+        let mut apu = Apu::default();
+        apu.set_filter_mode(HighPassFilter::Accurate);
+        let sample = 128;
+        let first = apu.filter_sample(sample, 0);
+        let second = apu.filter_sample(sample, 0);
+        assert_eq!(first, 128);
+        assert_eq!(second, 127);
     }
 
     #[test]
@@ -1719,7 +1730,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_filter_mode_resets_history() {
+    fn test_set_filter_mode_resets_diff() {
         let mut apu = Apu::default();
         apu.set_filter_mode(HighPassFilter::Preserve);
         let _ = apu.filter_sample(100, 0);
@@ -1729,7 +1740,7 @@ mod tests {
     }
 
     #[test]
-    fn test_state_preserves_filter_history() {
+    fn test_state_preserves_filter() {
         let mut apu = Apu::default();
         apu.set_filter_mode(HighPassFilter::Accurate);
         apu.filter_diff = [2.5, 3.5];

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -122,7 +122,7 @@ pub struct Apu {
     ch4_volume: u8,
     ch4_divisor: u8,
     ch4_width_mode: bool,
-    ch4_clock_shift: u8,
+    audio_buffer: VecDeque<i16>,
     ch4_lfsr: u16,
     ch4_length_enabled: bool,
     ch4_enabled: bool,
@@ -751,12 +751,13 @@ impl Apu {
                     | 0x38
             }
 
-            // 0xFF1B — NR31: Channel 3 length timer
-            NR31_ADDR => (255 - self.ch3_length_timer as u8).saturating_add(1),
-            // 0xFF1E — NR34: Channel 3 wavelength high & control
-            NR34_ADDR => {
-                (if self.ch3_length_enabled { 0x40 } else { 0x00 })
-                    | (if self.ch3_enabled { 0x80 } else { 0x00 })
+    pub fn output(&self) -> i16 {
+        let sample = self.ch1_output() + self.ch2_output() + self.ch3_output() + self.ch4_output();
+        ((sample as i16) - 128) << 8
+    fn filter_sample(&mut self, sample: i16, channel: usize) -> i16 {
+                output.clamp(i16::MIN as f32, i16::MAX as f32) as i16
+                let volume = ((volume_bits + 1.0) * 15.0 - 128.0) * 256.0;
+                output.clamp(i16::MIN as f32, i16::MAX as f32) as i16
                     | (((self.ch3_wave_length & (0x0700 >> 8)) as u8) << 3)
                     | 0x38
             }
@@ -869,8 +870,8 @@ impl Apu {
         }
     }
 
-    pub fn ch1_out_enabled(&self) -> bool {
-        self.ch1_out_enabled
+    pub fn audio_buffer(&self) -> &VecDeque<i16> {
+    pub fn audio_buffer_mut(&mut self) -> &mut VecDeque<i16> {
     }
 
     pub fn set_ch1_out_enabled(&mut self, enabled: bool) {
@@ -1624,10 +1625,10 @@ mod tests {
         assert_eq!(new_apu.ch2_direction, 0);
         assert_eq!(new_apu.ch2_volume, 10);
         assert_eq!(new_apu.ch2_wave_length, 1024);
-        assert!(new_apu.ch2_length_enabled);
-        assert!(new_apu.ch2_enabled);
-
-        assert_eq!(new_apu.ch3_timer, 9111);
+        let sample = 0i16;
+        let sample = 0i16;
+        assert_eq!(first, 0);
+        assert!(second.abs() <= 256);
         assert_eq!(new_apu.ch3_position, 7);
         assert_eq!(new_apu.ch3_output, 30);
         assert!(new_apu.ch3_dac);

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -811,7 +811,7 @@ impl Apu {
     /// of the outputs of all channels, this is used to
     /// calculate the final audio output that is going to be
     /// sent to the audio buffer.
-    /// 
+    ///
     /// This value is not filtered, it is the raw output
     /// of the channels, the filtering is done in the `filter_sample`
     /// method, which is called when the audio sample is created.
@@ -825,7 +825,7 @@ impl Apu {
 
     /// Filters the given sample based on the current filter mode
     /// and returns the filtered sample as an i16 value.
-    /// 
+    ///
     /// The `channel` parameter is used to determine which channel
     /// the sample belongs to, this is used to apply the correct
     /// filtering based on the channel's configuration.

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -1412,7 +1412,7 @@ impl Default for Apu {
 
 #[cfg(test)]
 mod tests {
-    use super::Apu;
+    use super::{Apu, HighPassFilter};
 
     use crate::state::StateComponent;
 
@@ -1631,5 +1631,34 @@ mod tests {
         assert_eq!(new_apu.sequencer_step, 6);
         assert_eq!(new_apu.output_timer, 789);
         assert_eq!(new_apu.filter_mode as u8, 2);
+    }
+
+    #[test]
+    fn test_filter_sample_disable() {
+        let mut apu = Apu::default();
+        let sample = 128;
+        let value = apu.filter_sample(sample, 0);
+        assert_eq!(value, sample);
+    }
+
+    #[test]
+    fn test_filter_sample_preserve() {
+        let mut apu = Apu::default();
+        apu.set_filter_mode(HighPassFilter::Preserve);
+        let sample = 128;
+        let first = apu.filter_sample(sample, 0);
+        let second = apu.filter_sample(sample, 0);
+        assert_eq!(first, 128);
+        assert_eq!(second, 127);
+    }
+
+    #[test]
+    fn test_set_filter_mode_resets_history() {
+        let mut apu = Apu::default();
+        apu.set_filter_mode(HighPassFilter::Preserve);
+        let _ = apu.filter_sample(100, 0);
+        apu.set_filter_mode(HighPassFilter::Accurate);
+        let value = apu.filter_sample(100, 0);
+        assert_eq!(value, 100);
     }
 }

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -888,16 +888,16 @@ impl GameBoy {
         self.apu_i().sampling_rate()
     }
 
+    pub fn audio_channels(&self) -> u8 {
+        self.apu_i().channels()
+    }
+
     pub fn audio_filter_mode(&self) -> HighPassFilter {
         self.apu_i().filter_mode()
     }
 
     pub fn set_audio_filter_mode(&mut self, mode: HighPassFilter) {
         self.apu().set_filter_mode(mode);
-    }
-
-    pub fn audio_channels(&self) -> u8 {
-        self.apu_i().channels()
     }
 
     pub fn cartridge_eager(&mut self) -> Cartridge {

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -29,7 +29,7 @@ use std::{
 };
 
 use crate::{
-    apu::Apu,
+    apu::{Apu, HighPassFilter},
     cheats::{
         genie::{GameGenie, GameGenieCode},
         shark::{GameShark, GameSharkCode},
@@ -1497,6 +1497,14 @@ impl GameBoy {
         if rom.game_shark().is_some() {
             rom.game_shark_mut().as_mut().unwrap().reset();
         }
+    }
+
+    pub fn audio_filter_mode(&self) -> HighPassFilter {
+        self.apu_i().filter_mode()
+    }
+
+    pub fn set_audio_filter_mode(&mut self, mode: HighPassFilter) {
+        self.apu().set_filter_mode(mode);
     }
 }
 

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -423,7 +423,7 @@ pub struct Registers {
 }
 
 pub trait AudioProvider {
-    fn audio_output(&self) -> i16;
+    fn audio_output(&self) -> u16;
     fn audio_buffer(&self) -> &VecDeque<i16>;
     fn clear_audio_buffer(&mut self);
 }
@@ -822,22 +822,22 @@ impl GameBoy {
         buffer
     }
 
-    pub fn audio_output(&self) -> i16 {
+    pub fn audio_output(&self) -> u16 {
         self.apu_i().output()
     }
 
-    pub fn audio_all_output(&self) -> Vec<i16> {
+    pub fn audio_all_output(&self) -> Vec<u16> {
         vec![
             self.audio_output(),
-    pub fn audio_ch1_output(&self) -> i16 {
-        self.apu_i().ch1_output() as i16
-    pub fn audio_ch2_output(&self) -> i16 {
-        self.apu_i().ch2_output() as i16
-    pub fn audio_ch3_output(&self) -> i16 {
-        self.apu_i().ch3_output() as i16
+            self.audio_ch1_output() as u16,
+            self.audio_ch2_output() as u16,
+            self.audio_ch3_output() as u16,
+            self.audio_ch4_output() as u16,
+        ]
+    }
 
-    pub fn audio_ch4_output(&self) -> i16 {
-        self.apu_i().ch4_output() as i16
+    pub fn audio_ch1_output(&self) -> u8 {
+        self.apu_i().ch1_output()
     }
 
     pub fn audio_ch2_output(&self) -> u8 {
@@ -1622,7 +1622,7 @@ pub fn hook_impl(info: &PanicInfo) {
 }
 
 impl AudioProvider for GameBoy {
-    fn audio_output(&self) -> i16 {
+    fn audio_output(&self) -> u16 {
         self.apu_i().output()
     }
 

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -888,6 +888,14 @@ impl GameBoy {
         self.apu_i().sampling_rate()
     }
 
+    pub fn audio_filter_mode(&self) -> HighPassFilter {
+        self.apu_i().filter_mode()
+    }
+
+    pub fn set_audio_filter_mode(&mut self, mode: HighPassFilter) {
+        self.apu().set_filter_mode(mode);
+    }
+
     pub fn audio_channels(&self) -> u8 {
         self.apu_i().channels()
     }
@@ -1497,14 +1505,6 @@ impl GameBoy {
         if rom.game_shark().is_some() {
             rom.game_shark_mut().as_mut().unwrap().reset();
         }
-    }
-
-    pub fn audio_filter_mode(&self) -> HighPassFilter {
-        self.apu_i().filter_mode()
-    }
-
-    pub fn set_audio_filter_mode(&mut self, mode: HighPassFilter) {
-        self.apu().set_filter_mode(mode);
     }
 }
 

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -423,8 +423,8 @@ pub struct Registers {
 }
 
 pub trait AudioProvider {
-    fn audio_output(&self) -> u8;
-    fn audio_buffer(&self) -> &VecDeque<u8>;
+    fn audio_output(&self) -> u16;
+    fn audio_buffer(&self) -> &VecDeque<i16>;
     fn clear_audio_buffer(&mut self);
 }
 
@@ -814,7 +814,7 @@ impl GameBoy {
         self.frame_buffer_raw().to_vec()
     }
 
-    pub fn audio_buffer_eager(&mut self, clear: bool) -> Vec<u8> {
+    pub fn audio_buffer_eager(&mut self, clear: bool) -> Vec<i16> {
         let buffer = Vec::from(self.audio_buffer().clone());
         if clear {
             self.clear_audio_buffer();
@@ -822,17 +822,17 @@ impl GameBoy {
         buffer
     }
 
-    pub fn audio_output(&self) -> u8 {
+    pub fn audio_output(&self) -> u16 {
         self.apu_i().output()
     }
 
-    pub fn audio_all_output(&self) -> Vec<u8> {
+    pub fn audio_all_output(&self) -> Vec<u16> {
         vec![
             self.audio_output(),
-            self.audio_ch1_output(),
-            self.audio_ch2_output(),
-            self.audio_ch3_output(),
-            self.audio_ch4_output(),
+            self.audio_ch1_output() as u16,
+            self.audio_ch2_output() as u16,
+            self.audio_ch3_output() as u16,
+            self.audio_ch4_output() as u16,
         ]
     }
 
@@ -1242,7 +1242,7 @@ impl GameBoy {
         self.ppu().frame_buffer_raw()
     }
 
-    pub fn audio_buffer(&mut self) -> &VecDeque<u8> {
+    pub fn audio_buffer(&mut self) -> &VecDeque<i16> {
         self.apu().audio_buffer()
     }
 
@@ -1622,11 +1622,11 @@ pub fn hook_impl(info: &PanicInfo) {
 }
 
 impl AudioProvider for GameBoy {
-    fn audio_output(&self) -> u8 {
+    fn audio_output(&self) -> u16 {
         self.apu_i().output()
     }
 
-    fn audio_buffer(&self) -> &VecDeque<u8> {
+    fn audio_buffer(&self) -> &VecDeque<i16> {
         self.apu_i().audio_buffer()
     }
 

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -892,14 +892,6 @@ impl GameBoy {
         self.apu_i().channels()
     }
 
-    pub fn audio_filter_mode(&self) -> HighPassFilter {
-        self.apu_i().filter_mode()
-    }
-
-    pub fn set_audio_filter_mode(&mut self, mode: HighPassFilter) {
-        self.apu().set_filter_mode(mode);
-    }
-
     pub fn cartridge_eager(&mut self) -> Cartridge {
         self.mmu().rom().clone()
     }
@@ -1461,6 +1453,14 @@ impl GameBoy {
         self.mmu().set_speed_callback(callback);
     }
 
+    pub fn audio_filter_mode(&self) -> HighPassFilter {
+        self.apu_i().filter_mode()
+    }
+
+    pub fn set_audio_filter_mode(&mut self, mode: HighPassFilter) {
+        self.apu().set_filter_mode(mode);
+    }
+
     pub fn add_cheat_code(&mut self, code: &str) -> Result<bool, Error> {
         if GameGenie::is_code(code) {
             return self.add_game_genie_code(code).map(|_| true);
@@ -1579,6 +1579,14 @@ impl GameBoy {
             .try_into()
             .unwrap();
         self.ppu().set_palette_colors(&palette);
+    }
+
+    pub fn audio_filter_mode_wa(&self) -> u8 {
+        self.apu_i().filter_mode().into()
+    }
+
+    pub fn set_audio_filter_mode_wa(&mut self, mode: u8) {
+        self.apu().set_filter_mode(mode.into());
     }
 
     fn js_to_pixel(value: &JsValue) -> Pixel {

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -423,7 +423,7 @@ pub struct Registers {
 }
 
 pub trait AudioProvider {
-    fn audio_output(&self) -> u16;
+    fn audio_output(&self) -> i16;
     fn audio_buffer(&self) -> &VecDeque<i16>;
     fn clear_audio_buffer(&mut self);
 }
@@ -822,22 +822,22 @@ impl GameBoy {
         buffer
     }
 
-    pub fn audio_output(&self) -> u16 {
+    pub fn audio_output(&self) -> i16 {
         self.apu_i().output()
     }
 
-    pub fn audio_all_output(&self) -> Vec<u16> {
+    pub fn audio_all_output(&self) -> Vec<i16> {
         vec![
             self.audio_output(),
-            self.audio_ch1_output() as u16,
-            self.audio_ch2_output() as u16,
-            self.audio_ch3_output() as u16,
-            self.audio_ch4_output() as u16,
-        ]
-    }
+    pub fn audio_ch1_output(&self) -> i16 {
+        self.apu_i().ch1_output() as i16
+    pub fn audio_ch2_output(&self) -> i16 {
+        self.apu_i().ch2_output() as i16
+    pub fn audio_ch3_output(&self) -> i16 {
+        self.apu_i().ch3_output() as i16
 
-    pub fn audio_ch1_output(&self) -> u8 {
-        self.apu_i().ch1_output()
+    pub fn audio_ch4_output(&self) -> i16 {
+        self.apu_i().ch4_output() as i16
     }
 
     pub fn audio_ch2_output(&self) -> u8 {
@@ -1622,7 +1622,7 @@ pub fn hook_impl(info: &PanicInfo) {
 }
 
 impl AudioProvider for GameBoy {
-    fn audio_output(&self) -> u16 {
+    fn audio_output(&self) -> i16 {
         self.apu_i().output()
     }
 


### PR DESCRIPTION
## Summary
- add high-pass filter enum and state to APU
- expose API for configuring the filter
- document new feature in README and CHANGELOG

## Testing
- `cargo fmt --all`
- `cargo clippy --fix --allow-dirty --allow-staged --all-features --all-targets -q`
- `black .`
- `cargo test --all-targets --features simd,debug,python`


------
https://chatgpt.com/codex/tasks/task_e_6847e484a3e48328b716f01667d36e55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced optional high-pass audio filter with three modes: Preserve, Accurate, and Disabled, including save-state support.
- **Documentation**
  - Updated changelog and README to reflect new audio filter options and enhanced audio capability descriptions.
- **Bug Fixes**
  - Improved audio sample handling in the Libretro frontend for more accurate output without scaling artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->