### PR TITLE
Add band-limited update scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * High-pass audio filter options (Preserve, Accurate, Disable) with save-state support
+* Band-limited audio update mode infrastructure
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- implement `UpdateMode` enum and band-limited step generator
- extend APU state with new update mode field
- add tests for new field
- document new feature in changelog

## Testing
- `cargo fmt --all`
- `cargo clippy --fix --allow-dirty --allow-staged --all-features --all-targets`
- `black .`
- `cargo test --all-targets --features simd,debug,python`


------
https://chatgpt.com/codex/tasks/task_e_6848a51d57d08328920634d4d3317a2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new band-limited audio update mode, providing improved audio synthesis with reduced aliasing.
  - Added options to select between direct and band-limited audio update modes.
  - Enhanced save-state functionality to preserve the selected audio update mode.

- **Documentation**
  - Updated changelog to include the new band-limited audio update mode infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->