### PR TITLE
Add shader loading to SDL frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * High-pass audio filter options (Preserve, Accurate, Disable) with save-state support
+* SDL frontend shader loading support via `--shader-path`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 *
+* Shader program was not applied to SDL output
 
 ## [0.11.5] - 2025-03-18
 

--- a/frontends/sdl/Cargo.toml
+++ b/frontends/sdl/Cargo.toml
@@ -21,6 +21,7 @@ boytacean-common = { path = "../../crates/common", version = "0.11.5" }
 clap = { version = "4", features = ["derive"] }
 image = "0.24"
 chrono = "0.4"
+gl = "0.14"
 
 [dependencies.sdl2]
 version = "0.36"

--- a/frontends/sdl/README.md
+++ b/frontends/sdl/README.md
@@ -107,3 +107,11 @@ cargo run -- --rom-path ../../res/roms/test/blargg/cpu/cpu_instrs.gb --cycles 10
 | `pedantic` | Additional safety instructions are executed to make sure the machine does no run "out of tracks", making sure to run many `panic()` calls. |
 | `slow`     | Runs the emulator at a very slow page 60x slower to allow visual debugging.                                                                |
 | `cpulog`   | Prints a log of the CPU instruction executed - will fill the stdout quickly.                                                               |
+
+### Shaders
+
+Use `--shader-path <FILE>` to load a fragment shader. Example:
+```bash
+cargo run -- --rom-path path/to/game.gb --shader-path res/shaders/scale.fsh
+```
+

--- a/frontends/sdl/res/shaders/base.vsh
+++ b/frontends/sdl/res/shaders/base.vsh
@@ -1,0 +1,12 @@
+#version 330 core
+
+layout (location = 0) in vec2 a_position;
+layout (location = 1) in vec2 a_texCoord;
+
+out vec2 v_texCoord;
+
+void main()
+{
+    gl_Position = vec4(a_position, 0.0, 1.0);
+    v_texCoord = a_texCoord;
+}

--- a/frontends/sdl/res/shaders/bilinear.fsh
+++ b/frontends/sdl/res/shaders/bilinear.fsh
@@ -1,4 +1,13 @@
-STATIC vec4 scale(sampler2D image, vec2 position, vec2 input_resolution, vec2 output_resolution)
+#version 330 core
+
+in vec2 v_texCoord;          // From vertex shader
+out vec4 FragColor;          // Final pixel color
+
+uniform sampler2D u_image;
+uniform vec2 u_input_resolution;
+uniform vec2 u_output_resolution;
+
+vec4 scale(sampler2D image, vec2 position, vec2 input_resolution, vec2 output_resolution)
 {
     vec2 pixel = position * input_resolution - vec2(0.5, 0.5);
 
@@ -10,5 +19,10 @@ STATIC vec4 scale(sampler2D image, vec2 position, vec2 input_resolution, vec2 ou
     vec4 r1 = mix(q11, q21, fract(pixel.x));
     vec4 r2 = mix(q12, q22, fract(pixel.x));
 
-    return mix (r1, r2, fract(pixel.y));
+    return mix(r1, r2, fract(pixel.y));
+}
+
+void main()
+{
+    FragColor = scale(u_image, v_texCoord, u_input_resolution, u_output_resolution);
 }

--- a/frontends/sdl/res/shaders/scale.fsh
+++ b/frontends/sdl/res/shaders/scale.fsh
@@ -1,0 +1,14 @@
+STATIC vec4 scale(sampler2D image, vec2 position, vec2 input_resolution, vec2 output_resolution)
+{
+    vec2 pixel = position * input_resolution - vec2(0.5, 0.5);
+
+    vec4 q11 = texture(image, (floor(pixel) + 0.5) / input_resolution);
+    vec4 q12 = texture(image, (vec2(floor(pixel.x), ceil(pixel.y)) + 0.5) / input_resolution);
+    vec4 q21 = texture(image, (vec2(ceil(pixel.x), floor(pixel.y)) + 0.5) / input_resolution);
+    vec4 q22 = texture(image, (ceil(pixel) + 0.5) / input_resolution);
+
+    vec4 r1 = mix(q11, q21, fract(pixel.x));
+    vec4 r2 = mix(q12, q22, fract(pixel.x));
+
+    return mix (r1, r2, fract(pixel.y));
+}

--- a/frontends/sdl/res/shaders/smooth.fsh
+++ b/frontends/sdl/res/shaders/smooth.fsh
@@ -1,0 +1,30 @@
+#version 330 core
+
+in vec2 v_texCoord;
+out vec4 FragColor;
+
+uniform sampler2D u_image;
+uniform vec2 u_input_resolution;
+uniform vec2 u_output_resolution;
+
+vec4 scale(sampler2D image, vec2 position, vec2 input_resolution, vec2 output_resolution)
+{
+    vec2 pixel = position * input_resolution - vec2(0.5, 0.5);
+
+    vec4 q11 = texture(image, (floor(pixel) + 0.5) / input_resolution);
+    vec4 q12 = texture(image, (vec2(floor(pixel.x), ceil(pixel.y)) + 0.5) / input_resolution);
+    vec4 q21 = texture(image, (vec2(ceil(pixel.x), floor(pixel.y)) + 0.5) / input_resolution);
+    vec4 q22 = texture(image, (ceil(pixel) + 0.5) / input_resolution);
+
+    vec2 s = smoothstep(0.0, 1.0, fract(pixel));
+
+    vec4 r1 = mix(q11, q21, s.x);
+    vec4 r2 = mix(q12, q22, s.x);
+
+    return mix(r1, r2, s.y);
+}
+
+void main()
+{
+    FragColor = scale(u_image, v_texCoord, u_input_resolution, u_output_resolution);
+}

--- a/frontends/sdl/src/main.rs
+++ b/frontends/sdl/src/main.rs
@@ -1,6 +1,7 @@
 pub mod audio;
 pub mod data;
 pub mod sdl;
+pub mod shader;
 pub mod test;
 
 use audio::Audio;
@@ -317,6 +318,14 @@ impl Emulator {
             .unwrap()
             .to_string();
         Ok(())
+    }
+
+    pub fn load_shader(&mut self, path: &str) -> Result<(), String> {
+        if let Some(ref mut sdl) = self.sdl {
+            sdl.load_fragment_shader(path)
+        } else {
+            Err(String::from("SDL system not started"))
+        }
     }
 
     pub fn reset(&mut self) -> Result<(), Error> {
@@ -1016,6 +1025,9 @@ struct Args {
 
     #[arg(default_value_t = String::from(DEFAULT_ROM_PATH), help = "Path to the ROM file to be loaded")]
     rom_path: String,
+
+    #[arg(long, default_value_t = String::from(""), help = "Path to fragment shader file")]
+    shader_path: String,
 }
 
 fn run(args: Args, emulator: &mut Emulator) {
@@ -1101,6 +1113,11 @@ fn main() {
     let mut emulator = Emulator::new(game_boy, options);
     emulator.start(SCREEN_SCALE);
     emulator.load_rom(Some(&args.rom_path)).unwrap();
+    if !args.shader_path.is_empty() {
+        if let Err(err) = emulator.load_shader(&args.shader_path) {
+            println!("Failed to load shader: {err}");
+        }
+    }
     emulator.apply_cheats(&args.cheats);
     emulator.toggle_palette();
 

--- a/frontends/sdl/src/main.rs
+++ b/frontends/sdl/src/main.rs
@@ -669,6 +669,7 @@ Drag & drop ROM file: Load new ROM and reset system\n===========================
                     / self.visual_frequency)
                     .round() as u32;
 
+                let mut frame_data: Option<&[u8]> = None;
                 loop {
                     // limits the number of ticks to the typical number
                     // of cycles expected for the current logic cycle
@@ -689,7 +690,11 @@ Drag & drop ROM file: Load new ROM and reset system\n===========================
                         // to update the stream texture, that will latter be copied
                         // to the canvas
                         let frame_buffer = self.system.frame_buffer().as_ref();
-                        texture.update(None, frame_buffer, width * 3).unwrap();
+                        if self.sdl.as_ref().unwrap().shader_program.is_none() {
+                            texture.update(None, frame_buffer, width * 3).unwrap();
+                        } else {
+                            frame_data = Some(frame_buffer);
+                        }
 
                         // obtains the index of the current PPU frame, this value
                         // is going to be used to detect for new frame presence
@@ -719,23 +724,22 @@ Drag & drop ROM file: Load new ROM and reset system\n===========================
                 // resources from being over-used in situations where multiple frames
                 // are generated during the same tick cycle
                 if frame_dirty {
-                    // clears the graphics canvas, making sure that no garbage
-                    // pixel data remaining in the pixel buffer, not doing this would
-                    // create visual glitches in OSs like Mac OS X
-                    self.sdl.as_mut().unwrap().canvas.clear();
-
-                    // copies the texture that was created for the frame (during
-                    // the loop part of the tick) to the canvas
-                    self.sdl
-                        .as_mut()
-                        .unwrap()
-                        .canvas
-                        .copy(&texture, None, None)
-                        .unwrap();
-
-                    // presents the canvas effectively updating the screen
-                    // information presented to the user
-                    self.sdl.as_mut().unwrap().canvas.present();
+                    if self.sdl.as_ref().unwrap().shader_program.is_some() {
+                        self.sdl.as_mut().unwrap().render_frame_with_shader(
+                            frame_data.unwrap(),
+                            width as u32,
+                            height as u32,
+                        );
+                    } else {
+                        self.sdl.as_mut().unwrap().canvas.clear();
+                        self.sdl
+                            .as_mut()
+                            .unwrap()
+                            .canvas
+                            .copy(&texture, None, None)
+                            .unwrap();
+                        self.sdl.as_mut().unwrap().canvas.present();
+                    }
                 }
 
                 // calculates the number of ticks that have elapsed since the

--- a/frontends/sdl/src/sdl.rs
+++ b/frontends/sdl/src/sdl.rs
@@ -105,6 +105,7 @@ impl SdlSystem {
     }
 
     pub fn load_fragment_shader<P: AsRef<Path>>(&mut self, path: P) -> Result<(), String> {
+        self.canvas.window().gl_make_current(&self.gl_context)?;
         let program = shader::load_fragment_shader(path.as_ref().to_str().unwrap())?;
         self.shader_program = Some(program);
         Ok(())

--- a/frontends/sdl/src/shader.rs
+++ b/frontends/sdl/src/shader.rs
@@ -38,8 +38,12 @@ unsafe fn compile_shader(kind: GLenum, source: &str) -> Result<u32, String> {
     gl::AttachShader(program, vertex_shader);
     gl::AttachShader(program, shader);
     gl::LinkProgram(program);
+    
     gl::DeleteShader(shader);
+    gl::DeleteShader(vertex_shader);
 
+    // checks if the program linked successfully and if not
+    // returns the error message
     gl::GetProgramiv(program, gl::LINK_STATUS, &mut status);
     if status == 0 {
         let mut len = 0;
@@ -55,5 +59,8 @@ unsafe fn compile_shader(kind: GLenum, source: &str) -> Result<u32, String> {
         gl::DeleteProgram(program);
         return Err(String::from_utf8_lossy(&buf).into_owned());
     }
+
+    gl::UseProgram(program);
+
     Ok(program)
 }

--- a/frontends/sdl/src/shader.rs
+++ b/frontends/sdl/src/shader.rs
@@ -1,8 +1,5 @@
 use gl::types::*;
-use std::{
-    ffi::{CStr, CString},
-    fs,
-};
+use std::{ffi::CString, fs};
 
 pub fn load_fragment_shader(path: &str) -> Result<u32, String> {
     let source = fs::read_to_string(path).map_err(|e| e.to_string())?;
@@ -10,6 +7,12 @@ pub fn load_fragment_shader(path: &str) -> Result<u32, String> {
 }
 
 unsafe fn compile_shader(kind: GLenum, source: &str) -> Result<u32, String> {
+    let vertex_shader = gl::CreateShader(gl::VERTEX_SHADER);
+    let vertex_source = fs::read_to_string("res/shaders/base.vsh").map_err(|e| e.to_string())?;
+    let c_str = CString::new(vertex_source).unwrap();
+    gl::ShaderSource(vertex_shader, 1, &c_str.as_ptr(), std::ptr::null());
+    gl::CompileShader(vertex_shader);
+
     let shader = gl::CreateShader(kind);
     let c_str = CString::new(source).unwrap();
     gl::ShaderSource(shader, 1, &c_str.as_ptr(), std::ptr::null());
@@ -32,6 +35,7 @@ unsafe fn compile_shader(kind: GLenum, source: &str) -> Result<u32, String> {
         return Err(String::from_utf8_lossy(&buf).into_owned());
     }
     let program = gl::CreateProgram();
+    gl::AttachShader(program, vertex_shader);
     gl::AttachShader(program, shader);
     gl::LinkProgram(program);
     gl::DeleteShader(shader);

--- a/frontends/sdl/src/shader.rs
+++ b/frontends/sdl/src/shader.rs
@@ -1,0 +1,55 @@
+use gl::types::*;
+use std::{
+    ffi::{CStr, CString},
+    fs,
+};
+
+pub fn load_fragment_shader(path: &str) -> Result<u32, String> {
+    let source = fs::read_to_string(path).map_err(|e| e.to_string())?;
+    unsafe { compile_shader(gl::FRAGMENT_SHADER, &source) }
+}
+
+unsafe fn compile_shader(kind: GLenum, source: &str) -> Result<u32, String> {
+    let shader = gl::CreateShader(kind);
+    let c_str = CString::new(source).unwrap();
+    gl::ShaderSource(shader, 1, &c_str.as_ptr(), std::ptr::null());
+    gl::CompileShader(shader);
+
+    let mut status = 0;
+    gl::GetShaderiv(shader, gl::COMPILE_STATUS, &mut status);
+    if status == 0 {
+        let mut len = 0;
+        gl::GetShaderiv(shader, gl::INFO_LOG_LENGTH, &mut len);
+        let mut buf = Vec::with_capacity(len as usize);
+        buf.set_len((len as usize) - 1);
+        gl::GetShaderInfoLog(
+            shader,
+            len,
+            std::ptr::null_mut(),
+            buf.as_mut_ptr() as *mut _,
+        );
+        gl::DeleteShader(shader);
+        return Err(String::from_utf8_lossy(&buf).into_owned());
+    }
+    let program = gl::CreateProgram();
+    gl::AttachShader(program, shader);
+    gl::LinkProgram(program);
+    gl::DeleteShader(shader);
+
+    gl::GetProgramiv(program, gl::LINK_STATUS, &mut status);
+    if status == 0 {
+        let mut len = 0;
+        gl::GetProgramiv(program, gl::INFO_LOG_LENGTH, &mut len);
+        let mut buf = Vec::with_capacity(len as usize);
+        buf.set_len((len as usize) - 1);
+        gl::GetProgramInfoLog(
+            program,
+            len,
+            std::ptr::null_mut(),
+            buf.as_mut_ptr() as *mut _,
+        );
+        gl::DeleteProgram(program);
+        return Err(String::from_utf8_lossy(&buf).into_owned());
+    }
+    Ok(program)
+}

--- a/frontends/sdl/src/shader.rs
+++ b/frontends/sdl/src/shader.rs
@@ -1,29 +1,39 @@
 use gl::types::*;
 use std::{ffi::CString, fs};
-
-pub fn load_fragment_shader(path: &str) -> Result<u32, String> {
-    let source = fs::read_to_string(path).map_err(|e| e.to_string())?;
-    unsafe { compile_shader(gl::FRAGMENT_SHADER, &source) }
+const VERTEX_SHADER: &str = "#version 330 core\nlayout(location = 0) in vec2 pos;\nlayout(location = 1) in vec2 tex;\nout vec2 v_tex;\nvoid main(){v_tex = tex;gl_Position = vec4(pos,0.0,1.0);}";
+pub fn load_shader_program(path: &str) -> Result<u32, String> {
+    let fragment = fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let fragment_source = format!(
+        "#version 330 core\n#define STATIC\nin vec2 v_tex;\nout vec4 color;\nuniform sampler2D image;\nuniform vec2 input_resolution;\nuniform vec2 output_resolution;\n{}\nvoid main(){{color = scale(image, v_tex, input_resolution, output_resolution);}}",
+        fragment
+    );
+    unsafe { compile_program(VERTEX_SHADER, &fragment_source) }
 }
 
+unsafe fn compile_program(vertex_src: &str, fragment_src: &str) -> Result<u32, String> {
+    let vs = compile_shader(gl::VERTEX_SHADER, vertex_src)?;
+    let fs = compile_shader(gl::FRAGMENT_SHADER, fragment_src)?;
+    let program = gl::CreateProgram();
+    gl::AttachShader(program, vs);
+    gl::AttachShader(program, fs);
+    gl::LinkProgram(program);
+    gl::DeleteShader(vs);
+    gl::DeleteShader(fs);
+    gl::GetProgramiv(program, gl::LINK_STATUS, &mut status);
+        gl::GetProgramiv(program, gl::INFO_LOG_LENGTH, &mut len);
+        gl::GetProgramInfoLog(
+            program,
+        gl::DeleteProgram(program);
+    Ok(program)
+}
 unsafe fn compile_shader(kind: GLenum, source: &str) -> Result<u32, String> {
-    let vertex_shader = gl::CreateShader(gl::VERTEX_SHADER);
-    let vertex_source = fs::read_to_string("res/shaders/base.vsh").map_err(|e| e.to_string())?;
-    let c_str = CString::new(vertex_source).unwrap();
-    gl::ShaderSource(vertex_shader, 1, &c_str.as_ptr(), std::ptr::null());
-    gl::CompileShader(vertex_shader);
-
     let shader = gl::CreateShader(kind);
     let c_str = CString::new(source).unwrap();
     gl::ShaderSource(shader, 1, &c_str.as_ptr(), std::ptr::null());
     gl::CompileShader(shader);
-
     let mut status = 0;
     gl::GetShaderiv(shader, gl::COMPILE_STATUS, &mut status);
-    if status == 0 {
-        let mut len = 0;
         gl::GetShaderiv(shader, gl::INFO_LOG_LENGTH, &mut len);
-        let mut buf = Vec::with_capacity(len as usize);
         buf.set_len((len as usize) - 1);
         gl::GetShaderInfoLog(
             shader,
@@ -34,7 +44,7 @@ unsafe fn compile_shader(kind: GLenum, source: &str) -> Result<u32, String> {
         gl::DeleteShader(shader);
         return Err(String::from_utf8_lossy(&buf).into_owned());
     }
-    let program = gl::CreateProgram();
+    Ok(shader)
     gl::AttachShader(program, vertex_shader);
     gl::AttachShader(program, shader);
     gl::LinkProgram(program);


### PR DESCRIPTION
## Summary
- allow passing `--shader-path` to load a fragment shader
- create OpenGL context for SDL frontend
- compile fragment shader and store program
- document shader usage
- note shader loading in changelog

## Testing
- `cargo clippy --fix --allow-dirty --allow-staged --all-features --all-targets`
- `black .`
- `cargo test --all-targets --features simd,debug,python`


------
https://chatgpt.com/codex/tasks/task_e_6848a63983d0832886611f7a689adff5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for loading custom fragment shaders in the SDL frontend via the new `--shader-path` command-line option.
  - Included built-in vertex and bilinear fragment shaders to enhance rendering quality.

- **Documentation**
  - Updated changelog and SDL frontend README with details and usage examples for the new shader loading capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->