### PR TITLE
Fix audio channel getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-*
+* Fixed `audio_ch1_enabled` returning the wrong channel status
 
 ## [0.11.5] - 2025-03-18
 

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -853,7 +853,7 @@ impl GameBoy {
     }
 
     pub fn audio_ch1_enabled(&self) -> bool {
-        self.apu_i().ch2_out_enabled()
+        self.apu_i().ch1_out_enabled()
     }
 
     pub fn set_audio_ch1_enabled(&mut self, enabled: bool) {


### PR DESCRIPTION
## Summary
- fix `audio_ch1_enabled` so it returns channel 1 status
- document fix in changelog

## Testing
- `cargo fmt --all`
- `cargo clippy --fix --allow-dirty --allow-staged --all-features --all-targets`
- `black .`
- `cargo test --all-targets --features simd,debug,python`


------
https://chatgpt.com/codex/tasks/task_e_6848a40a210c8328be0b1bfc846fd29b