### PR TITLE
Add WebGL shader support to web frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * High-pass audio filter options (Preserve, Accurate, Disable) with save-state support
 * SDL frontend shader loading support via `--shader-path`
+* Web frontend shader support using WebGL
 
 ### Changed
 

--- a/frontends/sdl/res/shaders/master.frag
+++ b/frontends/sdl/res/shaders/master.frag
@@ -1,4 +1,4 @@
-#version 330
+#version 330 core
 
 uniform sampler2D image;
 uniform sampler2D previous_image;

--- a/frontends/web/.parcelrc
+++ b/frontends/web/.parcelrc
@@ -3,6 +3,7 @@
     "transformers": {
         "*.{ts,tsx}": ["@parcel/transformer-typescript-tsc"],
         "*.{jpg,png,svg}": ["@parcel/transformer-raw"],
+        "*.{frag,vert}": ["@parcel/transformer-raw"],
         "*.{gb,gbc,wasm}": ["@parcel/transformer-raw"]
     }
 }

--- a/frontends/web/index.ts
+++ b/frontends/web/index.ts
@@ -59,11 +59,11 @@ const BACKGROUNDS = [
         backgrounds: BACKGROUNDS
     });
 
-    //if (shader) {
-    setTimeout(async () => {
-        await setupWebGL(emulator, "crt");
-    }, 3000);
-    //}
+    if (shader) {
+        setTimeout(async () => {
+            await setupWebGL(emulator, shader);
+        }, 3000);
+    }
 
     // sets the emulator in the global scope this is useful
     // to be able to access the emulator from global functions

--- a/frontends/web/index.ts
+++ b/frontends/web/index.ts
@@ -28,7 +28,7 @@ const BACKGROUNDS = [
     const fullscreen = ["1", "true", "True"].includes(
         params.get("fullscreen") ?? params.get("fs") ?? ""
     );
-    const shader = params.get("shader") ?? undefined;
+    const shader = params.get("shader") ?? "crt";
     const debug = ["1", "true", "True"].includes(params.get("debug") ?? "");
     const verbose = ["1", "true", "True"].includes(params.get("verbose") ?? "");
     const keyboard = ["1", "true", "True"].includes(
@@ -59,9 +59,11 @@ const BACKGROUNDS = [
         backgrounds: BACKGROUNDS
     });
 
-    if (shader) {
-        await setupWebGL(emulator, shader);
-    }
+    //if (shader) {
+    setTimeout(async () => {
+        await setupWebGL(emulator, "crt");
+    }, 3000);
+    //}
 
     // sets the emulator in the global scope this is useful
     // to be able to access the emulator from global functions

--- a/frontends/web/index.ts
+++ b/frontends/web/index.ts
@@ -1,6 +1,7 @@
 import { startApp } from "emukit";
 
 import { GameboyEmulator } from "./ts";
+import { setupWebGL } from "./ts/webgl";
 
 const BACKGROUNDS = [
     "264653",
@@ -27,6 +28,7 @@ const BACKGROUNDS = [
     const fullscreen = ["1", "true", "True"].includes(
         params.get("fullscreen") ?? params.get("fs") ?? ""
     );
+    const shader = params.get("shader") ?? undefined;
     const debug = ["1", "true", "True"].includes(params.get("debug") ?? "");
     const verbose = ["1", "true", "True"].includes(params.get("verbose") ?? "");
     const keyboard = ["1", "true", "True"].includes(
@@ -56,6 +58,10 @@ const BACKGROUNDS = [
         background: background,
         backgrounds: BACKGROUNDS
     });
+
+    if (shader) {
+        await setupWebGL(emulator, shader);
+    }
 
     // sets the emulator in the global scope this is useful
     // to be able to access the emulator from global functions

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -18,6 +18,7 @@
     },
     "source": "index.ts",
     "devDependencies": {
+        "@parcel/transformer-glsl": "2.15.2",
         "@parcel/transformer-typescript-tsc": "^2.14.0",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
@@ -44,6 +45,8 @@
     "alias": {
         "process": {
             "global": "process"
-        }
+        },
+        "react": "./node_modules/emukit/node_modules/react",
+        "react-dom": "./node_modules/emukit/node_modules/react-dom"
     }
 }

--- a/frontends/web/package.json
+++ b/frontends/web/package.json
@@ -45,8 +45,6 @@
     "alias": {
         "process": {
             "global": "process"
-        },
-        "react": "./node_modules/emukit/node_modules/react",
-        "react-dom": "./node_modules/emukit/node_modules/react-dom"
+        }
     }
 }

--- a/frontends/web/res/shaders/bilinear.frag
+++ b/frontends/web/res/shaders/bilinear.frag
@@ -1,0 +1,14 @@
+STATIC vec4 scale(sampler2D image, vec2 position, vec2 input_resolution, vec2 output_resolution)
+{
+    vec2 pixel = position * input_resolution - vec2(0.5, 0.5);
+
+    vec4 q11 = texture(image, (floor(pixel) + 0.5) / input_resolution);
+    vec4 q12 = texture(image, (vec2(floor(pixel.x), ceil(pixel.y)) + 0.5) / input_resolution);
+    vec4 q21 = texture(image, (vec2(ceil(pixel.x), floor(pixel.y)) + 0.5) / input_resolution);
+    vec4 q22 = texture(image, (ceil(pixel) + 0.5) / input_resolution);
+
+    vec4 r1 = mix(q11, q21, fract(pixel.x));
+    vec4 r2 = mix(q12, q22, fract(pixel.x));
+
+    return mix(r1, r2, fract(pixel.y));
+}

--- a/frontends/web/res/shaders/crt.frag
+++ b/frontends/web/res/shaders/crt.frag
@@ -1,0 +1,161 @@
+#define COLOR_LOW 0.45
+#define COLOR_HIGH 1.0
+#define VERTICAL_BORDER_DEPTH 0.6
+#define SCANLINE_DEPTH 0.55
+#define CURVENESS 0.3
+
+STATIC vec4 scale(sampler2D image, vec2 position, vec2 input_resolution, vec2 output_resolution)
+{
+    /* Curve and pixel ratio */
+    float y_curve = cos(position.x - 0.5) * CURVENESS + (1.0 - CURVENESS);
+    float y_multiplier = 8.0 / 7.0 / y_curve;
+    position.y *= y_multiplier;
+    position.y -= (y_multiplier - 1.0) / 2.0;
+    if (position.y < 0.0) return vec4(0,0,0,0);
+    if (position.y > 1.0) return vec4(0,0,0,0);
+
+    float x_curve = cos(position.y - 0.5) * CURVENESS + (1.0 - CURVENESS);
+    float x_multiplier = 1.0/x_curve;
+    position.x *= x_multiplier;
+    position.x -= (x_multiplier - 1.0) / 2.0;
+    if (position.x < 0.0) return vec4(0,0,0,0);
+    if (position.x > 1.0) return vec4(0,0,0,0);
+
+    /* Setting up common vars */
+    vec2 pos = fract(position * input_resolution);
+    vec2 sub_pos = pos * 6.0;
+
+    vec4 center = texture_relative(image, position, vec2(0, 0));
+    vec4 left = texture_relative(image, position, vec2(-1, 0));
+    vec4 right = texture_relative(image, position, vec2(1, 0));
+
+    /* Vertical blurring */
+    if (sub_pos.y < 1.0) {
+        center = mix(center, texture_relative(image, position, vec2( 0, -1)), 0.5 - sub_pos.y / 2.0);
+        left =   mix(left,   texture_relative(image, position, vec2(-1, -1)), 0.5 - sub_pos.y / 2.0);
+        right =  mix(right,  texture_relative(image, position, vec2( 1, -1)), 0.5 - sub_pos.y / 2.0);
+    }
+    else if (sub_pos.y > 5.0) {
+        center = mix(center, texture_relative(image, position, vec2( 0, 1)), (sub_pos.y - 5.0) / 2.0);
+        left =   mix(left,   texture_relative(image, position, vec2(-1, 1)), (sub_pos.y - 5.0) / 2.0);
+        right =  mix(right,  texture_relative(image, position, vec2( 1, 1)), (sub_pos.y - 5.0) / 2.0);
+    }
+
+    /* Scanlines */
+    float scanline_multiplier;
+    if (pos.y < 0.5) {
+        scanline_multiplier = (pos.y * 2.0) * SCANLINE_DEPTH + (1.0 - SCANLINE_DEPTH);
+    }
+    else  {
+        scanline_multiplier = ((1.0 - pos.y) * 2.0) * SCANLINE_DEPTH + (1.0 - SCANLINE_DEPTH);
+    }
+
+    center *= scanline_multiplier;
+    left *= scanline_multiplier;
+    right *= scanline_multiplier;
+
+    /* Vertical seperator for shadow masks */
+    bool odd = bool(int((position * input_resolution).x) & 1);
+    if (odd) {
+        pos.y += 0.5;
+        pos.y = fract(pos.y);
+    }
+
+    if (pos.y < 1.0 / 3.0) {
+        float gradient_position = pos.y * 3.0;
+        center *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+        left *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+        right *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+    }
+    else if (pos.y > 2.0 / 3.0) {
+        float gradient_position = (1.0 - pos.y) * 3.0;
+        center *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+        left *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+        right *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+    }
+
+    /* Blur the edges of the separators of adjacent columns */
+    if (sub_pos.x < 1.0 || sub_pos.x > 5.0) {
+        pos.y += 0.5;
+        pos.y = fract(pos.y);
+
+        if (pos.y < 1.0 / 3.0) {
+            float gradient_position = pos.y * 3.0;
+            if (pos.x < 0.5) {
+                gradient_position = 1.0 - (1.0 - gradient_position) * (1.0 - (pos.x) * 6.0);
+            }
+            else {
+                gradient_position = 1.0 - (1.0 - gradient_position) * (1.0 - (1.0 - pos.x) * 6.0);
+            }
+            center *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+            left *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+            right *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+        }
+        else if (pos.y > 2.0 / 3.0) {
+            float gradient_position = (1.0 - pos.y) * 3.0;
+            if (pos.x < 0.5) {
+                gradient_position = 1.0 - (1.0 - gradient_position) * (1.0 - (pos.x) * 6.0);
+            }
+            else {
+                gradient_position = 1.0 - (1.0 - gradient_position) * (1.0 - (1.0 - pos.x) * 6.0);
+            }
+            center *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+            left *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+            right *= gradient_position * VERTICAL_BORDER_DEPTH + (1.0 - VERTICAL_BORDER_DEPTH);
+        }
+    }
+
+    /* Subpixel blurring, like LCD filter*/
+
+    vec4 midleft = mix(left, center, 0.5);
+    vec4 midright = mix(right, center, 0.5);
+
+    vec4 ret;
+    if (sub_pos.x < 1.0) {
+        ret = mix(vec4(COLOR_HIGH * center.r, COLOR_LOW * center.g, COLOR_HIGH * left.b, 1),
+                  vec4(COLOR_HIGH * center.r, COLOR_LOW * center.g, COLOR_LOW  * left.b, 1),
+                  sub_pos.x);
+    }
+    else if (sub_pos.x < 2.0) {
+        ret = mix(vec4(COLOR_HIGH * center.r, COLOR_LOW  * center.g, COLOR_LOW * left.b, 1),
+                  vec4(COLOR_HIGH * center.r, COLOR_HIGH * center.g, COLOR_LOW * midleft.b, 1),
+                  sub_pos.x - 1.0);
+    }
+    else if (sub_pos.x < 3.0) {
+        ret = mix(vec4(COLOR_HIGH * center.r  , COLOR_HIGH * center.g, COLOR_LOW * midleft.b, 1),
+                  vec4(COLOR_LOW  * midright.r, COLOR_HIGH * center.g, COLOR_LOW * center.b, 1),
+                  sub_pos.x - 2.0);
+    }
+    else if (sub_pos.x < 4.0) {
+        ret = mix(vec4(COLOR_LOW * midright.r, COLOR_HIGH * center.g , COLOR_LOW  * center.b, 1),
+                  vec4(COLOR_LOW * right.r   , COLOR_HIGH  * center.g, COLOR_HIGH * center.b, 1),
+                  sub_pos.x - 3.0);
+    }
+    else if (sub_pos.x < 5.0) {
+        ret = mix(vec4(COLOR_LOW * right.r, COLOR_HIGH * center.g  , COLOR_HIGH * center.b, 1),
+                  vec4(COLOR_LOW * right.r, COLOR_LOW  * midright.g, COLOR_HIGH * center.b, 1),
+                  sub_pos.x - 4.0);
+    }
+    else {
+        ret = mix(vec4(COLOR_LOW  * right.r, COLOR_LOW * midright.g, COLOR_HIGH * center.b, 1),
+                  vec4(COLOR_HIGH * right.r, COLOR_LOW * right.g  ,  COLOR_HIGH * center.b, 1),
+                  sub_pos.x - 5.0);
+    }
+
+    /* Anti alias the curve */
+    vec2 pixel_position = position * output_resolution;
+    if (pixel_position.x < 1.0) {
+        ret *= pixel_position.x;
+    }
+    else if (pixel_position.x > output_resolution.x - 1.0) {
+        ret *= output_resolution.x - pixel_position.x;
+    }
+    if (pixel_position.y < 1.0) {
+        ret *= pixel_position.y;
+    }
+    else if (pixel_position.y > output_resolution.y - 1.0) {
+        ret *= output_resolution.y - pixel_position.y;
+    }
+
+    return ret;
+}

--- a/frontends/web/res/shaders/master.frag
+++ b/frontends/web/res/shaders/master.frag
@@ -1,0 +1,77 @@
+#version 330
+
+uniform sampler2D image;
+uniform sampler2D previous_image;
+uniform int frame_blending_mode;
+
+uniform vec2 output_resolution;
+uniform vec2 origin;
+
+#define equal(x, y) ((x) == (y))
+#define inequal(x, y) ((x) != (y))
+#define STATIC
+#define GAMMA (2.2)
+
+out vec4 frag_color;
+
+vec4 _texture(sampler2D t, vec2 pos)
+{
+    return pow(texture(t, pos), vec4(GAMMA));
+}
+
+vec4 texture_relative(sampler2D t, vec2 pos, vec2 offset)
+{
+    vec2 input_resolution = textureSize(t, 0);
+    return _texture(t, (floor(pos * input_resolution) + offset + vec2(0.5, 0.5)) / input_resolution);
+}
+
+#define texture _texture
+
+#line 1
+{filter}
+
+#define BLEND_BIAS (1.0/3.0)
+
+#define DISABLED 0
+#define SIMPLE 1
+#define ACCURATE 2
+#define ACCURATE_EVEN ACCURATE
+#define ACCURATE_ODD 3
+
+void main()
+{
+    vec2 position = gl_FragCoord.xy - origin;
+    position /= output_resolution;
+    position.y = 1 - position.y;
+    vec2 input_resolution = textureSize(image, 0);
+
+    float ratio;
+    switch (frame_blending_mode) {
+        default:
+        case DISABLED:
+            frag_color = pow(scale(image, position, input_resolution, output_resolution), vec4(1.0 / GAMMA));
+            return;
+        case SIMPLE:
+            ratio = 0.5;
+            break;
+        case ACCURATE_EVEN:
+            if ((int(position.y * input_resolution.y) & 1) == 0) {
+                ratio = BLEND_BIAS;
+            }
+            else {
+                ratio = 1 - BLEND_BIAS;
+            }
+            break;
+        case ACCURATE_ODD:
+            if ((int(position.y * input_resolution.y) & 1) == 0) {
+                ratio = 1 - BLEND_BIAS;
+            }
+            else {
+                ratio = BLEND_BIAS;
+            }
+            break;
+    }
+
+    frag_color = pow(mix(scale(image, position, input_resolution, output_resolution),
+                     scale(previous_image, position, input_resolution, output_resolution), ratio), vec4(1.0 / GAMMA));
+}

--- a/frontends/web/res/shaders/master.frag
+++ b/frontends/web/res/shaders/master.frag
@@ -1,4 +1,7 @@
-#version 330
+#version 300 es
+
+precision mediump float;
+precision mediump int;
 
 uniform sampler2D image;
 uniform sampler2D previous_image;
@@ -21,8 +24,8 @@ vec4 _texture(sampler2D t, vec2 pos)
 
 vec4 texture_relative(sampler2D t, vec2 pos, vec2 offset)
 {
-    vec2 input_resolution = textureSize(t, 0);
-    return _texture(t, (floor(pos * input_resolution) + offset + vec2(0.5, 0.5)) / input_resolution);
+    vec2 input_resolution = vec2(textureSize(t, 0));
+    return _texture(t, (floor(pos * input_resolution) + offset + vec2(0.5)) / input_resolution);
 }
 
 #define texture _texture
@@ -30,7 +33,7 @@ vec4 texture_relative(sampler2D t, vec2 pos, vec2 offset)
 #line 1
 {filter}
 
-#define BLEND_BIAS (1.0/3.0)
+#define BLEND_BIAS (1.0 / 3.0)
 
 #define DISABLED 0
 #define SIMPLE 1
@@ -42,36 +45,48 @@ void main()
 {
     vec2 position = gl_FragCoord.xy - origin;
     position /= output_resolution;
-    position.y = 1 - position.y;
-    vec2 input_resolution = textureSize(image, 0);
+    position.y = 1.0 - position.y;
 
-    float ratio;
+    vec2 input_resolution = vec2(textureSize(image, 0));
+
+    float ratio = 0.0;
+
     switch (frame_blending_mode) {
         default:
         case DISABLED:
-            frag_color = pow(scale(image, position, input_resolution, output_resolution), vec4(1.0 / GAMMA));
+            frag_color = pow(
+                scale(image, position, input_resolution, output_resolution),
+                vec4(1.0 / GAMMA)
+            );
             return;
+
         case SIMPLE:
             ratio = 0.5;
             break;
+
         case ACCURATE_EVEN:
-            if ((int(position.y * input_resolution.y) & 1) == 0) {
+            if ((int(floor(position.y * input_resolution.y)) & 1) == 0) {
                 ratio = BLEND_BIAS;
-            }
-            else {
-                ratio = 1 - BLEND_BIAS;
+            } else {
+                ratio = 1.0 - BLEND_BIAS;
             }
             break;
+
         case ACCURATE_ODD:
-            if ((int(position.y * input_resolution.y) & 1) == 0) {
-                ratio = 1 - BLEND_BIAS;
-            }
-            else {
+            if ((int(floor(position.y * input_resolution.y)) & 1) == 0) {
+                ratio = 1.0 - BLEND_BIAS;
+            } else {
                 ratio = BLEND_BIAS;
             }
             break;
     }
 
-    frag_color = pow(mix(scale(image, position, input_resolution, output_resolution),
-                     scale(previous_image, position, input_resolution, output_resolution), ratio), vec4(1.0 / GAMMA));
+    frag_color = pow(
+        mix(
+            scale(image, position, input_resolution, output_resolution),
+            scale(previous_image, position, input_resolution, output_resolution),
+            ratio
+        ),
+        vec4(1.0 / GAMMA)
+    );
 }

--- a/frontends/web/res/shaders/master.vert
+++ b/frontends/web/res/shaders/master.vert
@@ -1,0 +1,12 @@
+#version 330 core
+
+layout(location = 0) in vec2 pos;
+layout(location = 1) in vec2 tex;
+
+out vec2 v_tex;
+
+void main()
+{
+    v_tex = tex;
+    gl_Position = vec4(pos, 0.0, 1.0);
+}

--- a/frontends/web/res/shaders/master.vert
+++ b/frontends/web/res/shaders/master.vert
@@ -1,4 +1,4 @@
-#version 330 core
+#version 300 es
 
 layout(location = 0) in vec2 pos;
 layout(location = 1) in vec2 tex;

--- a/frontends/web/res/shaders/passthrough.frag
+++ b/frontends/web/res/shaders/passthrough.frag
@@ -1,0 +1,4 @@
+STATIC vec4 scale(sampler2D image, vec2 position, vec2 input_resolution, vec2 output_resolution)
+{
+    return texture(image, position);
+}

--- a/frontends/web/res/shaders/smooth_bilinear.frag
+++ b/frontends/web/res/shaders/smooth_bilinear.frag
@@ -1,0 +1,16 @@
+STATIC vec4 scale(sampler2D image, vec2 position, vec2 input_resolution, vec2 output_resolution)
+{
+    vec2 pixel = position * input_resolution - vec2(0.5, 0.5);
+
+    vec4 q11 = texture(image, (floor(pixel) + 0.5) / input_resolution);
+    vec4 q12 = texture(image, (vec2(floor(pixel.x), ceil(pixel.y)) + 0.5) / input_resolution);
+    vec4 q21 = texture(image, (vec2(ceil(pixel.x), floor(pixel.y)) + 0.5) / input_resolution);
+    vec4 q22 = texture(image, (ceil(pixel) + 0.5) / input_resolution);
+
+    vec2 s = smoothstep(0., 1., fract(pixel));
+
+    vec4 r1 = mix(q11, q21, s.x);
+    vec4 r2 = mix(q12, q22, s.x);
+
+    return mix(r1, r2, s.y);
+}

--- a/frontends/web/ts/webgl.ts
+++ b/frontends/web/ts/webgl.ts
@@ -105,6 +105,15 @@ async function fetchShader(path: string): Promise<string> {
     return await response.text();
 }
 
+/**
+ * Compiles a WebGL shader from source code, and returns the shader object.
+ * If compilation fails, logs the error message to the console and returns null.
+ *
+ * @param gl The WebGL2 rendering context.
+ * @param type The type of shader to compile (gl.VERTEX_SHADER or gl.FRAGMENT_SHADER).
+ * @param source The GLSL source code for the shader.
+ * @returns The compiled WebGL shader object, or null if compilation failed.
+ */
 function compileShader(
     gl: WebGL2RenderingContext,
     type: number,

--- a/frontends/web/ts/webgl.ts
+++ b/frontends/web/ts/webgl.ts
@@ -1,0 +1,121 @@
+export async function setupWebGL(emulator: any, shader: string) {
+    const canvas = document.querySelector<HTMLCanvasElement>(".display-canvas");
+    if (!canvas) return;
+    const gl = canvas.getContext("webgl2");
+    if (!gl) return;
+
+    const vertexSrc = await fetchShader("../res/shaders/master.vert");
+    const fragPartial = await fetchShader(getShaderPath(shader));
+    const masterFrag = await fetchShader("../res/shaders/master.frag");
+    const fragmentSrc = masterFrag.replace("{filter}", fragPartial);
+
+    const vertex = compileShader(gl, gl.VERTEX_SHADER, vertexSrc);
+    const fragment = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSrc);
+    if (!vertex || !fragment) return;
+
+    const program = createProgram(gl, vertex, fragment);
+    if (!program) return;
+
+    const vao = gl.createVertexArray();
+    const vbo = gl.createBuffer();
+    const vertices = new Float32Array([
+        -1, -1, 0, 0,
+        1, -1, 1, 0,
+        -1, 1, 0, 1,
+        1, 1, 1, 1
+    ]);
+
+    gl.bindVertexArray(vao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 16, 0);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 16, 8);
+    gl.enableVertexAttribArray(1);
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    gl.bindVertexArray(null);
+
+    const texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    const locImage = gl.getUniformLocation(program, "image");
+    const locOut = gl.getUniformLocation(program, "output_resolution");
+    const locOrigin = gl.getUniformLocation(program, "origin");
+
+    gl.useProgram(program);
+    gl.uniform1i(locImage, 0);
+
+    const draw = () => {
+        const buf = emulator.imageBuffer;
+        if (!buf) return;
+        const [w, h] = [emulator.dimensions.width, emulator.dimensions.height];
+        gl.activeTexture(gl.TEXTURE0);
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGB,
+            w,
+            h,
+            0,
+            gl.RGB,
+            gl.UNSIGNED_BYTE,
+            buf
+        );
+        gl.viewport(0, 0, canvas.width, canvas.height);
+        gl.uniform2f(locOut, canvas.width, canvas.height);
+        gl.uniform2f(locOrigin, 0, 0);
+        gl.bindVertexArray(vao);
+        gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    };
+
+    emulator.bind("frame", draw);
+};
+
+function getShaderPath(name: string): string {
+    switch (name) {
+        case "bilinear":
+            return "../res/shaders/bilinear.frag";
+        case "smooth":
+        case "smooth_bilinear":
+            return "../res/shaders/smooth_bilinear.frag";
+        case "crt":
+            return "../res/shaders/crt.frag";
+        default:
+            return "../res/shaders/passthrough.frag";
+    }
+}
+
+async function fetchShader(path: string): Promise<string> {
+    const response = await fetch(path);
+    return await response.text();
+}
+
+function compileShader(gl: WebGL2RenderingContext, type: number, source: string) {
+    const shader = gl.createShader(type);
+    if (!shader) return null;
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        console.error(gl.getShaderInfoLog(shader));
+        return null;
+    }
+    return shader;
+}
+
+function createProgram(gl: WebGL2RenderingContext, vs: WebGLShader, fs: WebGLShader) {
+    const program = gl.createProgram();
+    if (!program) return null;
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        console.error(gl.getProgramInfoLog(program));
+        return null;
+    }
+    return program;
+}

--- a/frontends/web/ts/webgl.ts
+++ b/frontends/web/ts/webgl.ts
@@ -93,7 +93,7 @@ function getShaderPath(name: string): string {
             return require("../res/shaders/smooth_bilinear.frag");
         case "crt":
             return require("../res/shaders/crt.frag");
-        case "pass":    
+        case "pass":
         case "passthrough":
         default:
             return require("../res/shaders/passthrough.frag");


### PR DESCRIPTION
## Summary
- add WebGL shader renderer in web frontend
- hook shader parameter in frontend to initialize WebGL
- copy shaders from SDL frontend
- document shader support in changelog

## Testing
- `cargo fmt --all`
- `cargo clippy --fix --allow-dirty --allow-staged --all-features --all-targets`
- `black .`
- `cargo test --all-targets --features simd,debug,python`


------
https://chatgpt.com/codex/tasks/task_e_684dbe78e5748328a39044ddde8b59cf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for Web frontend shader effects using WebGL, enabling enhanced visual rendering options in the web environment.
  - Added multiple built-in shader options, including bilinear, smooth bilinear, CRT, passthrough, and master shaders with frame blending.
  - Enabled frame blending and advanced scaling effects for improved image quality in the web frontend.
  - Added dynamic shader selection via URL parameter for customizable visual effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->