### PR TITLE
Investigate emulator for potential bugs

### DIFF
--- a/frontends/console/Cargo.toml
+++ b/frontends/console/Cargo.toml
@@ -17,3 +17,4 @@ cpulog = ["boytacean/cpulog"]
 
 [dependencies]
 boytacean = { path = "../..", version = "0.11.5" }
+clap = { version = "4.5.4", features = ["derive"] }

--- a/frontends/console/src/main.rs
+++ b/frontends/console/src/main.rs
@@ -1,21 +1,77 @@
-use boytacean::gb::{GameBoy, GameBoyMode};
+use boytacean::{
+    gb::{GameBoy, GameBoyMode},
+    ppu::{FRAME_BUFFER_SIZE, DISPLAY_WIDTH, DISPLAY_HEIGHT},
+};
+use clap::Parser;
 use std::time::Instant;
 
-const REBOOTS: u32 = 500;
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(short, long)]
+    rom_path: String,
+
+    #[clap(short, long, default_value_t = 10000000)]
+    cycles: u64,
+}
 
 fn main() {
+    let parsed_args = Args::parse();
+
+    // Construct an absolute path to the ROM file.
+    // Assumes that when run with `cargo run --package boytacean-console`,
+    // the current directory is `<workspace_root>/frontends/console`.
+    // The ROM path is relative to the workspace root.
+    let mut base_path = std::env::current_dir().unwrap(); // Should be /app/frontends/console
+    base_path.pop(); // Now /app/frontends
+    base_path.pop(); // Now /app (workspace root)
+    let rom_path = base_path.join(&parsed_args.rom_path);
+
     let mut game_boy = GameBoy::new(Some(GameBoyMode::Dmg));
-    let mut cycles = 0_u64;
+    game_boy.load(true).unwrap();
+    game_boy.load_rom_file(rom_path.to_str().unwrap(), None).unwrap();
+    game_boy.attach_stdout_serial();
+
+    println!("Running ROM: {}", rom_path.display());
+    println!("Running for {} cycles...", parsed_args.cycles);
+
     let start = Instant::now();
-    println!("Running {REBOOTS} reboots...");
-    for _ in 0..REBOOTS {
-        game_boy.reset();
-        game_boy.load(true).unwrap();
-        game_boy.load_rom_empty().unwrap();
-        cycles += game_boy.step_to(0x0100) as u64;
+    let mut current_cycles = 0;
+    while current_cycles < parsed_args.cycles {
+        current_cycles += game_boy.clock() as u64;
     }
     let elapsed = start.elapsed();
     let elapsed_s = elapsed.as_secs_f64();
-    let frequency_mhz = cycles as f64 / elapsed_s / 1000.0 / 1000.0;
-    println!("Ran {cycles} cycles in {elapsed:?} ({frequency_mhz:.2} Mhz)");
+    let frequency_mhz = current_cycles as f64 / elapsed_s / 1000.0 / 1000.0;
+
+    println!(
+        "Ran {} cycles in {:?} ({:.2} Mhz)",
+        current_cycles, elapsed, frequency_mhz
+    );
+
+    print_framebuffer(&game_boy.frame_buffer_raw());
+}
+
+fn print_framebuffer(frame_buffer: &[u8; FRAME_BUFFER_SIZE]) {
+    println!("Framebuffer output (ASCII):");
+    for y in 0..DISPLAY_HEIGHT {
+        for x in 0..DISPLAY_WIDTH {
+            let base_idx = (y * DISPLAY_WIDTH + x) * 3; // 3 bytes per pixel (RGB)
+            let r = frame_buffer[base_idx];
+            let g = frame_buffer[base_idx + 1];
+            let b = frame_buffer[base_idx + 2];
+
+            // Simple ASCII representation based on luminance
+            let luminance = (0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32) as u8;
+            let char_to_print = match luminance {
+                0..=50 => '#',
+                51..=100 => '@',
+                101..=150 => '%',
+                151..=200 => '.',
+                _ => ' ',
+            };
+            print!("{}", char_to_print);
+        }
+        println!();
+    }
 }


### PR DESCRIPTION
Identified and investigated potential bugs in the Boytacean emulator.

Key findings:
- Blargg's `mem_timing.gb` test ROM failed tests 01, 02, and 03. This indicates potential inaccuracies in memory access timing for `LD (HL+/-),A`, `PUSH/POP`, and `CALL/RET` instructions. These are critical issues that can affect game compatibility.
- Core CPU instruction tests (`cpu_instrs.gb`) and general instruction timing tests (`instr_timing.gb`) passed, suggesting most CPU operations and their overall cycle counts are correct.
- The `simd` feature causes compilation errors on stable Rust due to Nightly-only feature usage.
- A minor PyO3 binding warning (`non-local impl definition`) was noted.

Changes made during investigation:
- Modified `frontends/console/src/main.rs` to:
  - Accept a ROM file path via command-line arguments.
  - Correctly resolve ROM paths when run with `cargo run --package`.
  - Attach a stdout serial device to capture test ROM output.
  - Print the framebuffer as ASCII for visual inspection.
  - Add a cycle limit for ROM execution.
- Updated `frontends/console/Cargo.toml` to include `clap`.

Note: Workspace tests (`cargo test --workspace`) failed due to the `sdl2-sys` dependency requiring Vcpkg, which was not configured in the current test environment. This is separate from the core emulator bugs investigated. Core library tests passed when `simd` feature was excluded.