### PR TITLE
perf: core emulation performance audit and hot path tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Keyboard navigation in the game playlist (arrow keys to browse results, Enter to load)
+* Performance profiling support with per-frame timings, render timings and memory access counters - [#34](https://github.com/joamag/boytacean/issues/34)
+* Performance audit document with benchmark comparisons against other emulators - [#34](https://github.com/joamag/boytacean/issues/34)
 
 ### Changed
 
-*
+* Faster background rendering and main loop clocking with identical emulation output - [#34](https://github.com/joamag/boytacean/issues/34)
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ simd = ["boytacean-encoding/simd", "boytacean-hashing/simd"]
 debug = []
 pedantic = []
 cpulog = []
+profile = []
 gen-mock = []
 
 [dependencies]

--- a/doc/benchmarks.md
+++ b/doc/benchmarks.md
@@ -1,0 +1,49 @@
+# Benchmarks
+
+Timestamped benchmark reports comparing Boytacean against other Game Boy emulators. Each section is a self-contained snapshot with the exact environment, versions and raw per-round data, so that results remain reproducible and comparable over time. The methodology is described in [performance.md](performance.md).
+
+## 2026-07-09 — DMG/CGB frame throughput vs mGBA and SameBoy
+
+### Environment
+
+| Item | Value |
+| ---- | ----- |
+| Hardware | Apple M5 Pro (18 cores), macOS 26.5.1 |
+| Boytacean | `feat/core-perf-tuning` (`3f6c34a`, v0.12.1 base), rustc 1.95.0, release profile (fat LTO, `opt-level = 3`) |
+| mGBA | `master` (`5157ce2`, 2026-07-05), `mgba-perf` built with `-DBUILD_PERF=ON`, Release |
+| SameBoy | `master`, tester v1.0.3, `make tester CONF=release` |
+
+### Harnesses
+
+* **Boytacean**: `bench_headless` example, best of 3 runs of 12000 frames, 600 warmup frames, APU disabled by default (`--apu` column enables it).
+* **mGBA**: `mgba-perf -F 12000`, 3 runs, audio always emulated (no audio sync).
+* **SameBoy**: `sameboy_tester --dmg --length 200` (200 emulated seconds = 12000 frames) wall-clock timed, 3 runs, full accuracy mode, audio always emulated. The tester simulates button presses during the run, a minor workload difference versus the other harnesses.
+
+Boytacean and mGBA runs were interleaved to bound scheduling/thermal drift (~±3% run-to-run on this machine).
+
+### Results (fps, best of 3 runs)
+
+| ROM | Mode | Boytacean | Boytacean (APU) | mGBA | SameBoy |
+| --- | ---- | --------- | --------------- | ---- | ------- |
+| pocket.gb | DMG | 16318 | 12068 | 8595 | 2510 |
+| shocklobster.gb | DMG | 17188 | 11628 | 21868 | 2532 |
+| opus5.gb | DMG | 18492 | 14387 | 8435 | n/a |
+| cgb_acid2.gbc | CGB | 10439 | - | 22986 | 4196 |
+
+The SameBoy tester aborts early on opus5.gb (its stuck-game heuristic triggers on the demo's idle loop), so no valid measurement is possible with that harness. The cgb_acid2.gbc Boytacean/mGBA values are from a single measurement pass.
+
+### Raw per-round data (fps)
+
+| ROM | Boytacean | Boytacean (APU) | mGBA | SameBoy |
+| --- | --------- | --------------- | ---- | ------- |
+| pocket.gb | 16318 / 15378 / 15755 | 12068 / 11697 / 11695 | 8595 / 8352 / 8325 | 2505 / 2500 / 2510 |
+| shocklobster.gb | 16802 / 16284 / 17188 | 11223 / 11216 / 11628 | 21499 / 21868 / 20981 | 2532 / 2505 / 2521 |
+| opus5.gb | 18227 / 18045 / 18492 | 14387 / 13950 / 14008 | 8384 / 8435 / 8347 | n/a |
+| cgb_acid2.gbc | 10439 | - | 22986 | 4110 / 4196 / 4110 |
+
+### Findings
+
+* With audio enabled on both sides, Boytacean is ~1.4x (pocket.gb) to ~1.7x (opus5.gb) faster than mGBA on rendering-bound DMG workloads.
+* mGBA is ~1.9x faster on shocklobster.gb (interrupt and HALT heavy action game) and ~2.2x faster on the CGB test ROM, consistent with its event-driven scheduler skipping idle emulation work that Boytacean ticks through 4 cycles at a time.
+* SameBoy trades throughput for accuracy (per-T-cycle stepping) and runs at ~2500 fps (DMG) / ~4200 fps (CGB), roughly 5-8x slower than Boytacean and mGBA, while remaining far above realtime.
+* All three emulators are comfortably above the ~60 fps realtime requirement on this hardware; the differences only matter for fast-forward, headless and AI-training style workloads.

--- a/doc/benchmarks.md
+++ b/doc/benchmarks.md
@@ -6,12 +6,12 @@ Timestamped benchmark reports comparing Boytacean against other Game Boy emulato
 
 ### Environment
 
-| Item | Value |
-| ---- | ----- |
-| Hardware | Apple M5 Pro (18 cores), macOS 26.5.1 |
+| Item      | Value                                                                                                       |
+| --------- | ----------------------------------------------------------------------------------------------------------- |
+| Hardware  | Apple M5 Pro (18 cores), macOS 26.5.1                                                                       |
 | Boytacean | `feat/core-perf-tuning` (`3f6c34a`, v0.12.1 base), rustc 1.95.0, release profile (fat LTO, `opt-level = 3`) |
-| mGBA | `master` (`5157ce2`, 2026-07-05), `mgba-perf` built with `-DBUILD_PERF=ON`, Release |
-| SameBoy | `master`, tester v1.0.3, `make tester CONF=release` |
+| mGBA      | `master` (`5157ce2`, 2026-07-05), `mgba-perf` built with `-DBUILD_PERF=ON`, Release                         |
+| SameBoy   | `master`, tester v1.0.3, `make tester CONF=release`                                                         |
 
 ### Harnesses
 
@@ -23,23 +23,23 @@ Boytacean and mGBA runs were interleaved to bound scheduling/thermal drift (~±3
 
 ### Results (fps, best of 3 runs)
 
-| ROM | Mode | Boytacean | Boytacean (APU) | mGBA | SameBoy |
-| --- | ---- | --------- | --------------- | ---- | ------- |
-| pocket.gb | DMG | 16318 | 12068 | 8595 | 2510 |
-| shocklobster.gb | DMG | 17188 | 11628 | 21868 | 2532 |
-| opus5.gb | DMG | 18492 | 14387 | 8435 | n/a |
-| cgb_acid2.gbc | CGB | 10439 | - | 22986 | 4196 |
+| ROM             | Mode | Boytacean | Boytacean (APU) | mGBA  | SameBoy |
+| --------------- | ---- | --------- | --------------- | ----- | ------- |
+| pocket.gb       | DMG  | 16318     | 12068           | 8595  | 2510    |
+| shocklobster.gb | DMG  | 17188     | 11628           | 21868 | 2532    |
+| opus5.gb        | DMG  | 18492     | 14387           | 8435  | n/a     |
+| cgb_acid2.gbc   | CGB  | 10439     | -               | 22986 | 4196    |
 
 The SameBoy tester aborts early on opus5.gb (its stuck-game heuristic triggers on the demo's idle loop), so no valid measurement is possible with that harness. The cgb_acid2.gbc Boytacean/mGBA values are from a single measurement pass.
 
 ### Raw per-round data (fps)
 
-| ROM | Boytacean | Boytacean (APU) | mGBA | SameBoy |
-| --- | --------- | --------------- | ---- | ------- |
-| pocket.gb | 16318 / 15378 / 15755 | 12068 / 11697 / 11695 | 8595 / 8352 / 8325 | 2505 / 2500 / 2510 |
+| ROM             | Boytacean             | Boytacean (APU)       | mGBA                  | SameBoy            |
+| --------------- | --------------------- | --------------------- | --------------------- | ------------------ |
+| pocket.gb       | 16318 / 15378 / 15755 | 12068 / 11697 / 11695 | 8595 / 8352 / 8325    | 2505 / 2500 / 2510 |
 | shocklobster.gb | 16802 / 16284 / 17188 | 11223 / 11216 / 11628 | 21499 / 21868 / 20981 | 2532 / 2505 / 2521 |
-| opus5.gb | 18227 / 18045 / 18492 | 14387 / 13950 / 14008 | 8384 / 8435 / 8347 | n/a |
-| cgb_acid2.gbc | 10439 | - | 22986 | 4110 / 4196 / 4110 |
+| opus5.gb        | 18227 / 18045 / 18492 | 14387 / 13950 / 14008 | 8384 / 8435 / 8347    | n/a                |
+| cgb_acid2.gbc   | 10439                 | -                     | 22986                 | 4110 / 4196 / 4110 |
 
 ### Findings
 

--- a/doc/benchmarks.md
+++ b/doc/benchmarks.md
@@ -2,6 +2,23 @@
 
 Timestamped benchmark reports comparing Boytacean against other Game Boy emulators. Each section is a self-contained snapshot with the exact environment, versions and raw per-round data, so that results remain reproducible and comparable over time. The methodology is described in [performance.md](performance.md).
 
+## 2026-07-10 — CGB rendering tuning
+
+Environment identical to the 2026-07-09 section below, measuring the effect of the CGB rendering optimizations (borrowed background attributes map and per-tile row slice rendering in `render_map()`). Before is the branch state of the 2026-07-09 report, after includes the CGB rendering changes. Runs were interleaved, 3 rounds of 12000 frames each.
+
+### Results (fps, per round)
+
+| ROM           | Mode | Before                | After                 | mGBA (2026-07-09) |
+| ------------- | ---- | --------------------- | --------------------- | ----------------- |
+| cgb_acid2.gbc | CGB  | 10966 / 10771 / 10437 | 12512 / 12167 / 12408 | 22986             |
+
+### Findings
+
+* The CGB background attributes map (`[TileData; 1024]`, 5 KB) was copied by value on every scanline render pass; borrowing it instead yields +13-19% CGB frame throughput.
+* Background map rendering dropped from ~45% to ~37% of the CGB frame time (internal `profile` instrumentation).
+* Emulation output remains bit-exact (frame-buffer hashes match across cgb-acid2 and game ROMs in DMG and CGB modes).
+* The remaining gap to mGBA on CGB (~1.8x) is dominated by the halt-tick loop, consistent with the event-scheduler future work item in [performance.md](performance.md).
+
 ## 2026-07-09 — DMG/CGB frame throughput vs mGBA and SameBoy
 
 ### Environment

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -19,16 +19,18 @@ Emulation output equivalence was verified by hashing the complete frame buffer o
 
 Frames per second, best of three interleaved runs of 12000 frames, higher is better:
 
-| ROM | Mode | Boytacean | Boytacean (APU) | mGBA |
-| --- | ---- | --------- | --------------- | ---- |
-| pocket.gb | DMG | 16318 | 12068 | 8595 |
-| shocklobster.gb | DMG | 17188 | 11628 | 21868 |
-| opus5.gb | DMG | 18492 | 14387 | 8435 |
-| cgb_acid2.gbc | CGB | 10439 | - | 22986 |
+| ROM | Mode | Boytacean | Boytacean (APU) | mGBA | SameBoy |
+| --- | ---- | --------- | --------------- | ---- | ------- |
+| pocket.gb | DMG | 16318 | 12068 | 8595 | 2510 |
+| shocklobster.gb | DMG | 17188 | 11628 | 21868 | 2532 |
+| opus5.gb | DMG | 18492 | 14387 | 8435 | n/a |
+| cgb_acid2.gbc | CGB | 10439 | - | 22986 | 4196 |
 
-With audio emulation on both sides, Boytacean is ~1.4-1.7x faster than mGBA on typical DMG workloads, while mGBA is ~1.9x faster on shocklobster (a sprite and interrupt heavy action game) and ~2.2x faster on the CGB test ROM. The pattern is consistent with the audit findings below: Boytacean wins on rendering-bound scenes, mGBA wins on halt/interrupt-bound and CGB scenes thanks to its event-driven scheduler.
+With audio emulation on both sides, Boytacean is ~1.4-1.7x faster than mGBA on typical DMG workloads, while mGBA is ~1.9x faster on shocklobster (a sprite and interrupt heavy action game) and ~2.2x faster on the CGB test ROM. The pattern is consistent with the audit findings below: Boytacean wins on rendering-bound scenes, mGBA wins on halt/interrupt-bound and CGB scenes thanks to its event-driven scheduler. SameBoy trades throughput for maximum accuracy (per-T-cycle stepping) and runs roughly 5-8x slower than the other two, while remaining far above realtime.
 
-Notes on fairness: `mgba-perf` always emulates audio, so the closest comparison column is Boytacean with `--apu`. mGBA is also a full-system emulator whose Game Boy core (SM83) favours accuracy features (event scheduler, cycle-level timings) that Boytacean's simpler loop does not implement.
+The timestamped report with the exact environment, versions, harness details and raw per-round data is kept in [benchmarks.md](benchmarks.md).
+
+Notes on fairness: `mgba-perf` and the SameBoy tester always emulate audio, so the closest comparison column is Boytacean with `--apu`. mGBA is also a full-system emulator whose Game Boy core (SM83) favours accuracy features (event scheduler, cycle-level timings) that Boytacean's simpler loop does not implement.
 
 ## Internal profiling
 

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -24,9 +24,9 @@ Frames per second, best of three interleaved runs of 12000 frames, higher is bet
 | pocket.gb       | DMG  | 16318     | 12068           | 8595  | 2510    |
 | shocklobster.gb | DMG  | 17188     | 11628           | 21868 | 2532    |
 | opus5.gb        | DMG  | 18492     | 14387           | 8435  | n/a     |
-| cgb_acid2.gbc   | CGB  | 10439     | -               | 22986 | 4196    |
+| cgb_acid2.gbc   | CGB  | 12512     | -               | 22986 | 4196    |
 
-With audio emulation on both sides, Boytacean is ~1.4-1.7x faster than mGBA on typical DMG workloads, while mGBA is ~1.9x faster on shocklobster (a sprite and interrupt heavy action game) and ~2.2x faster on the CGB test ROM. The pattern is consistent with the audit findings below: Boytacean wins on rendering-bound scenes, mGBA wins on halt/interrupt-bound and CGB scenes thanks to its event-driven scheduler. SameBoy trades throughput for maximum accuracy (per-T-cycle stepping) and runs roughly 5-8x slower than the other two, while remaining far above realtime.
+With audio emulation on both sides, Boytacean is ~1.4-1.7x faster than mGBA on typical DMG workloads, while mGBA is ~1.9x faster on shocklobster (a sprite and interrupt heavy action game) and ~1.8x faster on the CGB test ROM. The pattern is consistent with the audit findings below: Boytacean wins on rendering-bound scenes, mGBA wins on halt/interrupt-bound and CGB scenes thanks to its event-driven scheduler. SameBoy trades throughput for maximum accuracy (per-T-cycle stepping) and runs roughly 5-8x slower than the other two, while remaining far above realtime.
 
 The timestamped report with the exact environment, versions, harness details and raw per-round data is kept in [benchmarks.md](benchmarks.md).
 
@@ -77,6 +77,8 @@ The following low-risk optimizations were applied, keeping the emulation output 
 * DMG background/window rendering fetches a tile row slice once per tile instead of computing a per-pixel tile buffer index, mirroring the approach already used for objects.
 * Object height is computed once per scanline instead of once per OAM entry in `render_objects()`.
 * The hot `Tile` accessors (`get`, `get_flipped`, `get_row`) are now marked `#[inline(always)]`.
+* The CGB background attributes map is borrowed instead of copied in `render_map()`, removing a 5 KB copy per scanline pass (background map rendering went from ~45% to ~37% of the CGB frame time, +13-19% CGB frame throughput).
+* CGB background/window rendering uses the same per-tile row slice approach as DMG, resolving the X/Y flip attributes once per tile instead of once per pixel.
 
 The combined effect on frame throughput is in the +1% to +6% range depending on the workload (largest on background-heavy scenes), with no regression on any of the benchmarked ROMs. On the `cpu_cycles` criterion benchmark, which isolates the clocking loop, the improvement is ~13% (510 us to 445 us per iteration).
 
@@ -88,5 +90,5 @@ Higher-impact opportunities that require structural changes and were intentional
 * **Event-driven scheduling (mGBA style)**: instead of ticking every component every 4 cycles during `HALT`, compute the next event timestamp (PPU mode transition, timer overflow, DMA completion) and jump directly to it. This is the main architectural difference explaining mGBA's advantage on CPU-heavy workloads.
 * **Flat page-table memory map (Gambatte/mGBA style)**: replace the nested `match` plus MBC function-pointer dispatch with a precomputed table of page pointers for plain-memory regions, reserving the slow path for IO registers. This would cut the cost of every opcode fetch and memory operand access.
 * **Deferred CGB pixel expansion**: CGB rendering writes 3 RGB bytes per pixel in the hot loop, while DMG mode already defers the palette expansion to `frame_buffer()`. Applying the same technique to CGB would remove the per-pixel palette dereference and stores.
-* **Avoid the per-scanline `bg_map_attrs` copy (CGB)**: `render_map()` copies the background attributes array by value on every scanline; borrowing it instead requires restructuring the borrows in the render path.
+* **APU event scheduling**: enabling the APU costs ~25-30% of frame throughput because all four channel timers are ticked on every clock call. The channels cannot be batched naively (channel periods can be as short as 4 cycles), so this requires the same event-scheduler treatment as the main loop.
 * **Reusable DMA/frame buffers**: OAM DMA and HDMA allocate a temporary `Vec` per transfer and `clocks_frame_buffer()` allocates a fresh frame copy per frame; both are once-per-frame level costs, relevant mostly for FFI-heavy consumers (Python/WASM).

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -19,12 +19,12 @@ Emulation output equivalence was verified by hashing the complete frame buffer o
 
 Frames per second, best of three interleaved runs of 12000 frames, higher is better:
 
-| ROM | Mode | Boytacean | Boytacean (APU) | mGBA | SameBoy |
-| --- | ---- | --------- | --------------- | ---- | ------- |
-| pocket.gb | DMG | 16318 | 12068 | 8595 | 2510 |
-| shocklobster.gb | DMG | 17188 | 11628 | 21868 | 2532 |
-| opus5.gb | DMG | 18492 | 14387 | 8435 | n/a |
-| cgb_acid2.gbc | CGB | 10439 | - | 22986 | 4196 |
+| ROM             | Mode | Boytacean | Boytacean (APU) | mGBA  | SameBoy |
+| --------------- | ---- | --------- | --------------- | ----- | ------- |
+| pocket.gb       | DMG  | 16318     | 12068           | 8595  | 2510    |
+| shocklobster.gb | DMG  | 17188     | 11628           | 21868 | 2532    |
+| opus5.gb        | DMG  | 18492     | 14387           | 8435  | n/a     |
+| cgb_acid2.gbc   | CGB  | 10439     | -               | 22986 | 4196    |
 
 With audio emulation on both sides, Boytacean is ~1.4-1.7x faster than mGBA on typical DMG workloads, while mGBA is ~1.9x faster on shocklobster (a sprite and interrupt heavy action game) and ~2.2x faster on the CGB test ROM. The pattern is consistent with the audit findings below: Boytacean wins on rendering-bound scenes, mGBA wins on halt/interrupt-bound and CGB scenes thanks to its event-driven scheduler. SameBoy trades throughput for maximum accuracy (per-T-cycle stepping) and runs roughly 5-8x slower than the other two, while remaining far above realtime.
 

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -1,0 +1,90 @@
+# Performance
+
+This document describes the performance characteristics of the Boytacean emulation core, the results of a structured audit of its hot paths, a benchmark comparison against other Game Boy emulators and the list of optimization opportunities that were identified (both the ones already applied and the ones left as future work).
+
+## Methodology
+
+All measurements were taken on an Apple M5 Pro (macOS), using release builds (`opt-level = 3`, fat LTO, single codegen unit) and the `bench_headless` example, which clocks the emulator as fast as possible with the APU disabled (unless stated otherwise) and no frame-buffer extraction:
+
+```bash
+cargo build --release --example bench_headless
+./target/release/examples/bench_headless <rom.gb> [frames] [--apu] [--cgb]
+```
+
+The comparison against [mGBA](https://mgba.io) uses the `mgba-perf` tool built from the mGBA `master` branch (`cmake -DBUILD_PERF=ON`), running the same ROMs for the same number of frames. Numbers are the best of three interleaved runs of 12000 frames each, which bounds the run-to-run noise (~±3% on this machine, mostly scheduling and thermal effects).
+
+Emulation output equivalence was verified by hashing the complete frame buffer of every frame across long runs (dmg-acid2, cgb-acid2 and multiple game ROMs, in both DMG and CGB modes) before and after the changes, with bit-exact results.
+
+## Results
+
+Frames per second, best of three interleaved runs of 12000 frames, higher is better:
+
+| ROM | Mode | Boytacean | Boytacean (APU) | mGBA |
+| --- | ---- | --------- | --------------- | ---- |
+| pocket.gb | DMG | 16318 | 12068 | 8595 |
+| shocklobster.gb | DMG | 17188 | 11628 | 21868 |
+| opus5.gb | DMG | 18492 | 14387 | 8435 |
+| cgb_acid2.gbc | CGB | 10439 | - | 22986 |
+
+With audio emulation on both sides, Boytacean is ~1.4-1.7x faster than mGBA on typical DMG workloads, while mGBA is ~1.9x faster on shocklobster (a sprite and interrupt heavy action game) and ~2.2x faster on the CGB test ROM. The pattern is consistent with the audit findings below: Boytacean wins on rendering-bound scenes, mGBA wins on halt/interrupt-bound and CGB scenes thanks to its event-driven scheduler.
+
+Notes on fairness: `mgba-perf` always emulates audio, so the closest comparison column is Boytacean with `--apu`. mGBA is also a full-system emulator whose Game Boy core (SM83) favours accuracy features (event scheduler, cycle-level timings) that Boytacean's simpler loop does not implement.
+
+## Internal profiling
+
+The `profile` feature adds low-overhead instrumentation to the emulation core, giving visibility over where the time is spent and how memory is accessed, without any cost when the feature is disabled:
+
+```bash
+cargo build --release --example bench_headless --features profile
+./target/release/examples/bench_headless <rom.gb> [frames]
+```
+
+The gathered metrics include per-frame time, background/window and object rendering times, instruction and rendered line counters and MMU read/write counters per memory region. Timing is only measured around chunky operations (complete frames and scanline render passes) so that the timer overhead does not skew the attribution, while the counters are updated per event.
+
+Example output for a typical DMG game (values per benchmark run):
+
+```text
+Frame            354.665 ms (100.00%)
+Render BG         54.251 ms (15.30%)
+Render OBJ        15.660 ms ( 4.42%)
+Other            284.754 ms (80.29%)
+Frames        5000
+Instructions  84853026
+Render lines  720000
+APU samples   0
+Reads         5101766 (rom=3137912 vram=0 eram=0 wram=1282783 oam=0 io=9650 hram=665000)
+Writes        1177724 (rom=0 vram=0 eram=0 wram=290722 oam=800000 io=52002 hram=35000)
+```
+
+## Audit findings
+
+The main findings of the audit, from profiling data and code inspection:
+
+* The emulation loop runs at roughly 3.5-4 ns per `clock()` call in release builds, meaning most micro-optimizations are at the ~1% level and hard to distinguish from measurement noise.
+* Games spend the large majority of each frame in the `HALT` state waiting for the V-Blank interrupt, and every halted tick (4 cycles) still pays the full loop cost: interrupt flag synthesis from five separate component flags, speed normalization and the clocking of all devices. This per-tick overhead, not rendering, dominates the frame time (~80%).
+* Background/window map rendering accounts for ~15% of frame time and object rendering for ~4% in sprite-heavy DMG games.
+* Memory access is dominated by ROM reads (~61%), followed by WRAM (~25%) and HRAM (~13%). OAM writes are almost entirely produced by the per-frame OAM DMA transfer.
+* Logging and assertion machinery (`debug`, `pedantic`, `cpulog` features) is cleanly compiled out of release builds and does not leak into the hot path.
+
+## Applied optimizations
+
+The following low-risk optimizations were applied, keeping the emulation output bit-exact:
+
+* Interrupt flag synthesis in `Cpu::clock()` is now skipped when it cannot affect execution (IME disabled and not halted, or no interrupt source enabled in IE).
+* Cycle normalization for double speed (CGB) uses a shift (`GameBoySpeed::shift()`) instead of an integer division on every `clock()` call.
+* DMG background/window rendering fetches a tile row slice once per tile instead of computing a per-pixel tile buffer index, mirroring the approach already used for objects.
+* Object height is computed once per scanline instead of once per OAM entry in `render_objects()`.
+* The hot `Tile` accessors (`get`, `get_flipped`, `get_row`) are now marked `#[inline(always)]`.
+
+The combined effect on frame throughput is in the +1% to +6% range depending on the workload (largest on background-heavy scenes), with no regression on any of the benchmarked ROMs. On the `cpu_cycles` criterion benchmark, which isolates the clocking loop, the improvement is ~13% (510 us to 445 us per iteration).
+
+## Future work
+
+Higher-impact opportunities that require structural changes and were intentionally left out of the safe tuning pass:
+
+* **Cached IF register**: the interrupt flags are currently synthesized from five booleans scattered across the PPU, timer, serial and gamepad on every instruction. Maintaining a single hardware-like IF byte updated at raise/acknowledge time would collapse the per-tick interrupt check to one AND operation. This is the single most promising change given the halt-dominated profile.
+* **Event-driven scheduling (mGBA style)**: instead of ticking every component every 4 cycles during `HALT`, compute the next event timestamp (PPU mode transition, timer overflow, DMA completion) and jump directly to it. This is the main architectural difference explaining mGBA's advantage on CPU-heavy workloads.
+* **Flat page-table memory map (Gambatte/mGBA style)**: replace the nested `match` plus MBC function-pointer dispatch with a precomputed table of page pointers for plain-memory regions, reserving the slow path for IO registers. This would cut the cost of every opcode fetch and memory operand access.
+* **Deferred CGB pixel expansion**: CGB rendering writes 3 RGB bytes per pixel in the hot loop, while DMG mode already defers the palette expansion to `frame_buffer()`. Applying the same technique to CGB would remove the per-pixel palette dereference and stores.
+* **Avoid the per-scanline `bg_map_attrs` copy (CGB)**: `render_map()` copies the background attributes array by value on every scanline; borrowing it instead requires restructuring the borrows in the render path.
+* **Reusable DMA/frame buffers**: OAM DMA and HDMA allocate a temporary `Vec` per transfer and `clocks_frame_buffer()` allocates a fresh frame copy per frame; both are once-per-frame level costs, relevant mostly for FFI-heavy consumers (Python/WASM).

--- a/examples/bench_headless.rs
+++ b/examples/bench_headless.rs
@@ -2,10 +2,11 @@
 //!
 //! No Python boundary, no per-component instrumentation and no
 //! frame-buffer extraction. APU is disabled (matching the typical
-//! AI training configuration). Reports best-of-three runs.
+//! AI training configuration) unless the `--apu` flag is provided.
+//! Reports best-of-three runs.
 //!
 //! # Usage
-//! cargo run --release --example bench_headless -- <rom.gb> [frames]
+//! cargo run --release --example bench_headless -- <rom.gb> [frames] [--apu] [--cgb]
 
 use std::{env::args, error::Error, time::Instant};
 
@@ -19,7 +20,7 @@ const RUNS: usize = 3;
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = args().collect();
     if args.len() < 2 {
-        println!("Usage: bench_headless <rom.gb> [frames]");
+        println!("Usage: bench_headless <rom.gb> [frames] [--apu] [--cgb]");
         return Ok(());
     }
     let rom_path = &args[1];
@@ -27,17 +28,26 @@ fn main() -> Result<(), Box<dyn Error>> {
         .get(2)
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_FRAMES);
+    let apu_enabled = args.iter().any(|arg| arg == "--apu");
+    let mode = if args.iter().any(|arg| arg == "--cgb") {
+        GameBoyMode::Cgb
+    } else {
+        GameBoyMode::Dmg
+    };
 
     let mut best_ns: u128 = u128::MAX;
     for run in 1..=RUNS {
-        let mut gb = GameBoy::new(Some(GameBoyMode::Dmg));
+        let mut gb = GameBoy::new(Some(mode));
         gb.load(true)?;
         gb.load_rom_file(rom_path, None)?;
-        gb.set_apu_enabled(false);
+        gb.set_apu_enabled(apu_enabled);
 
         for _ in 0..WARMUP {
             gb.next_frame();
         }
+
+        #[cfg(feature = "profile")]
+        GameBoy::reset_profile();
 
         let t0 = Instant::now();
         for _ in 0..frames {
@@ -54,6 +64,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             elapsed as f64 / 1000.0 / frames as f64,
         );
         best_ns = best_ns.min(elapsed);
+
+        #[cfg(feature = "profile")]
+        GameBoy::dump_profile();
     }
 
     let best_fps = frames as f64 / (best_ns as f64 / 1e9);

--- a/src/apu.rs
+++ b/src/apu.rs
@@ -22,6 +22,7 @@ use crate::{
     },
     gb::GameBoy,
     mmu::BusComponent,
+    profile_count_gb,
     state::{StateComponent, StateFormat},
     warnln,
 };
@@ -421,6 +422,8 @@ impl Apu {
 
         self.output_timer = self.output_timer.saturating_sub(cycles as i16);
         if self.output_timer <= 0 {
+            profile_count_gb!(apu_samples);
+
             // verifies if we've reached the maximum allowed size for the
             // audio buffer and if that's the case an item is removed from
             // the buffer (avoiding overflow)

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -171,13 +171,20 @@ impl Cpu {
 
         // fetches the current interrupt request flags (IF) with the enabled
         // mask (IE) applied, each interrupt flag is fetched once so that both
-        // the halt release check and the handler dispatch reuse the same value
-        let flags = (self.mmu.ppu().int_vblank() as u8)
-            | ((self.mmu.ppu().int_stat() as u8) << 1)
-            | ((self.mmu.timer().int_tima() as u8) << 2)
-            | ((self.mmu.serial().int_serial() as u8) << 3)
-            | ((self.mmu.pad().int_pad() as u8) << 4);
-        let pending = flags & self.mmu.ie;
+        // the halt release check and the handler dispatch reuse the same value,
+        // the (expensive) fetch operation is only performed when the pending
+        // value can affect execution (IME set or halted) and at least one
+        // interrupt source is enabled, otherwise it would be discarded
+        let pending = if (self.ime || self.halted) && self.mmu.ie != 0 {
+            let flags = (self.mmu.ppu().int_vblank() as u8)
+                | ((self.mmu.ppu().int_stat() as u8) << 1)
+                | ((self.mmu.timer().int_tima() as u8) << 2)
+                | ((self.mmu.serial().int_serial() as u8) << 3)
+                | ((self.mmu.pad().int_pad() as u8) << 4);
+            flags & self.mmu.ie
+        } else {
+            0
+        };
 
         // in case the CPU execution is halted and there's a pending interrupt
         // while IME is disabled, releases the CPU from the halted state so that
@@ -994,6 +1001,38 @@ mod tests {
         assert_eq!(cycles, 4);
         assert_eq!(cpu.pc, 0xc001);
         assert!(!cpu.halted);
+        assert!(cpu.mmu.ppu().int_vblank());
+    }
+
+    /// Tests that an interrupt request is ignored when no interrupt
+    /// source is enabled (IE empty), both in the normal and in the
+    /// halted states.
+    #[test]
+    fn test_int_ignored_ie_empty() {
+        let mut cpu = Cpu::default();
+        cpu.boot();
+        cpu.mmu.allocate_default();
+
+        cpu.pc = 0xc000;
+        cpu.sp = 0xfffe;
+        cpu.mmu.write(0xc000, 0x00);
+        cpu.mmu.ie = 0x00;
+        cpu.mmu.ppu().set_int_vblank(true);
+        cpu.enable_int();
+
+        let cycles = cpu.clock();
+        assert_eq!(cycles, 4);
+        assert_eq!(cpu.pc, 0xc001);
+        assert_eq!(cpu.sp, 0xfffe);
+        assert!(cpu.mmu.ppu().int_vblank());
+
+        cpu.pc = 0xc000;
+        cpu.halted = true;
+
+        let cycles = cpu.clock();
+        assert_eq!(cycles, 4);
+        assert_eq!(cpu.pc, 0xc000);
+        assert!(cpu.halted);
         assert!(cpu.mmu.ppu().int_vblank());
     }
 }

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -50,7 +50,8 @@ pub struct Profile {
     /// Number of frames executed.
     pub frames: u64,
 
-    /// Number of CPU instructions executed.
+    /// Number of CPU clock steps executed (including `HALT` ticks),
+    /// i.e. the number of `Cpu::clock()` calls, not just decoded opcodes.
     pub instructions: u64,
 
     /// Number of PPU lines rendered.

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -4,6 +4,8 @@
 //! a global instance of the emulator, which is going to be used
 //! in panic diagnostics
 
+#[cfg(feature = "profile")]
+use std::fmt::{self, Display, Formatter};
 use std::ptr::null;
 
 use crate::gb::GameBoy;
@@ -15,6 +17,204 @@ static mut GLOBAL_INSTANCE: *const GameBoy = null();
 // Static mutable flag to enable or disable pedantic diagnostics.
 #[cfg(feature = "pedantic")]
 pub static mut PEDANTIC: bool = true;
+
+/// Static mutable instance of the profile structure to be used
+/// in the gathering of performance metrics of the emulator.
+#[cfg(feature = "profile")]
+pub static mut PROFILE: Profile = Profile::new();
+
+/// Structure that gathers a series of performance metrics
+/// (times and counters) from the emulator internals, to be
+/// used for profiling purposes.
+///
+/// The metrics are gathered globally using the [`profile_time_gb`],
+/// [`profile_count_gb`], [`profile_read_gb`] and [`profile_write_gb`]
+/// macros, which are no-ops when the `profile` feature is disabled.
+#[cfg(feature = "profile")]
+#[derive(Clone, Copy, Debug)]
+pub struct Profile {
+    /// Time spent running complete frames (in nanoseconds).
+    ///
+    /// This value works as the base reference for the other
+    /// timing values, as it includes the complete emulation
+    /// time (CPU, PPU, APU, DMA, timer and serial).
+    pub frame_time: u64,
+
+    /// Time spent rendering the background and window maps
+    /// (in nanoseconds).
+    pub render_bg_time: u64,
+
+    /// Time spent rendering the objects (in nanoseconds).
+    pub render_obj_time: u64,
+
+    /// Number of frames executed.
+    pub frames: u64,
+
+    /// Number of CPU instructions executed.
+    pub instructions: u64,
+
+    /// Number of PPU lines rendered.
+    pub render_lines: u64,
+
+    /// Number of APU samples synthesized.
+    pub apu_samples: u64,
+
+    /// Number of MMU reads from the ROM area (0x0000-0x7FFF).
+    pub reads_rom: u64,
+
+    /// Number of MMU reads from the VRAM area (0x8000-0x9FFF).
+    pub reads_vram: u64,
+
+    /// Number of MMU reads from the external RAM area (0xA000-0xBFFF).
+    pub reads_eram: u64,
+
+    /// Number of MMU reads from the work RAM area (0xC000-0xFDFF).
+    pub reads_wram: u64,
+
+    /// Number of MMU reads from the OAM area (0xFE00-0xFE9F).
+    pub reads_oam: u64,
+
+    /// Number of MMU reads from the IO registers area (0xFEA0-0xFF7F, 0xFFFF).
+    pub reads_io: u64,
+
+    /// Number of MMU reads from the HRAM area (0xFF80-0xFFFE).
+    pub reads_hram: u64,
+
+    /// Number of MMU writes to the ROM area (0x0000-0x7FFF).
+    pub writes_rom: u64,
+
+    /// Number of MMU writes to the VRAM area (0x8000-0x9FFF).
+    pub writes_vram: u64,
+
+    /// Number of MMU writes to the external RAM area (0xA000-0xBFFF).
+    pub writes_eram: u64,
+
+    /// Number of MMU writes to the work RAM area (0xC000-0xFDFF).
+    pub writes_wram: u64,
+
+    /// Number of MMU writes to the OAM area (0xFE00-0xFE9F).
+    pub writes_oam: u64,
+
+    /// Number of MMU writes to the IO registers area (0xFEA0-0xFF7F, 0xFFFF).
+    pub writes_io: u64,
+
+    /// Number of MMU writes to the HRAM area (0xFF80-0xFFFE).
+    pub writes_hram: u64,
+}
+
+#[cfg(feature = "profile")]
+impl Profile {
+    pub const fn new() -> Self {
+        Self {
+            frame_time: 0,
+            render_bg_time: 0,
+            render_obj_time: 0,
+            frames: 0,
+            instructions: 0,
+            render_lines: 0,
+            apu_samples: 0,
+            reads_rom: 0,
+            reads_vram: 0,
+            reads_eram: 0,
+            reads_wram: 0,
+            reads_oam: 0,
+            reads_io: 0,
+            reads_hram: 0,
+            writes_rom: 0,
+            writes_vram: 0,
+            writes_eram: 0,
+            writes_wram: 0,
+            writes_oam: 0,
+            writes_io: 0,
+            writes_hram: 0,
+        }
+    }
+
+    /// Total time spent rendering both the background and window
+    /// maps and the objects (in nanoseconds).
+    pub fn render_time(&self) -> u64 {
+        self.render_bg_time + self.render_obj_time
+    }
+
+    /// Total number of MMU read operations executed.
+    pub fn total_reads(&self) -> u64 {
+        self.reads_rom
+            + self.reads_vram
+            + self.reads_eram
+            + self.reads_wram
+            + self.reads_oam
+            + self.reads_io
+            + self.reads_hram
+    }
+
+    /// Total number of MMU write operations executed.
+    pub fn total_writes(&self) -> u64 {
+        self.writes_rom
+            + self.writes_vram
+            + self.writes_eram
+            + self.writes_wram
+            + self.writes_oam
+            + self.writes_io
+            + self.writes_hram
+    }
+
+    pub fn description(&self) -> String {
+        let total = self.frame_time.max(1);
+        let time_line = |name: &str, time: u64| -> String {
+            format!(
+                "{:<14}{:>10.3} ms ({:>5.2}%)\n",
+                name,
+                time as f64 / 1e6,
+                time as f64 * 100.0 / total as f64
+            )
+        };
+        String::new()
+            + &time_line("Frame", self.frame_time)
+            + &time_line("Render BG", self.render_bg_time)
+            + &time_line("Render OBJ", self.render_obj_time)
+            + &time_line("Other", self.frame_time.saturating_sub(self.render_time()))
+            + &format!("Frames        {}\n", self.frames)
+            + &format!("Instructions  {}\n", self.instructions)
+            + &format!("Render lines  {}\n", self.render_lines)
+            + &format!("APU samples   {}\n", self.apu_samples)
+            + &format!(
+                "Reads         {} (rom={} vram={} eram={} wram={} oam={} io={} hram={})\n",
+                self.total_reads(),
+                self.reads_rom,
+                self.reads_vram,
+                self.reads_eram,
+                self.reads_wram,
+                self.reads_oam,
+                self.reads_io,
+                self.reads_hram
+            )
+            + &format!(
+                "Writes        {} (rom={} vram={} eram={} wram={} oam={} io={} hram={})",
+                self.total_writes(),
+                self.writes_rom,
+                self.writes_vram,
+                self.writes_eram,
+                self.writes_wram,
+                self.writes_oam,
+                self.writes_io,
+                self.writes_hram
+            )
+    }
+}
+
+#[cfg(feature = "profile")]
+impl Default for Profile {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "profile")]
+impl Display for Profile {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
 
 impl GameBoy {
     /// Sets the current instance as the one going to be used
@@ -68,6 +268,30 @@ impl GameBoy {
     fn dump_diagnostics_s(&self) {
         println!("Dumping Boytacean diagnostics:");
         println!("{}", self.description_debug());
+    }
+
+    /// Obtains a copy of the global profile instance with the
+    /// performance metrics gathered so far.
+    #[cfg(feature = "profile")]
+    pub fn profile() -> Profile {
+        unsafe { PROFILE }
+    }
+
+    /// Resets the global profile instance to its initial state,
+    /// effectively clearing all of the gathered metrics.
+    #[cfg(feature = "profile")]
+    pub fn reset_profile() {
+        unsafe {
+            PROFILE = Profile::new();
+        }
+    }
+
+    /// Dumps the performance metrics gathered by the global
+    /// profile instance into stdout.
+    #[cfg(feature = "profile")]
+    pub fn dump_profile() {
+        println!("Dumping Boytacean profile:");
+        println!("{}", Self::profile());
     }
 }
 
@@ -158,4 +382,165 @@ macro_rules! assert_pedantic_gb {
     ($cond:expr) => {
         ()
     };
+}
+
+#[cfg(feature = "profile")]
+#[macro_export]
+macro_rules! profile_time_gb {
+    ($field:ident, $expr:expr) => {{
+        let instant = std::time::Instant::now();
+        let result = $expr;
+        unsafe {
+            $crate::diag::PROFILE.$field += instant.elapsed().as_nanos() as u64;
+        }
+        result
+    }};
+}
+
+#[cfg(not(feature = "profile"))]
+#[macro_export]
+macro_rules! profile_time_gb {
+    ($field:ident, $expr:expr) => {
+        $expr
+    };
+}
+
+#[cfg(feature = "profile")]
+#[macro_export]
+macro_rules! profile_count_gb {
+    ($field:ident) => {
+        unsafe {
+            $crate::diag::PROFILE.$field += 1;
+        }
+    };
+}
+
+#[cfg(not(feature = "profile"))]
+#[macro_export]
+macro_rules! profile_count_gb {
+    ($field:ident) => {
+        ()
+    };
+}
+
+#[cfg(feature = "profile")]
+#[macro_export]
+macro_rules! profile_read_gb {
+    ($addr:expr) => {{
+        let addr = $addr;
+        unsafe {
+            match addr {
+                0x0000..=0x7fff => $crate::diag::PROFILE.reads_rom += 1,
+                0x8000..=0x9fff => $crate::diag::PROFILE.reads_vram += 1,
+                0xa000..=0xbfff => $crate::diag::PROFILE.reads_eram += 1,
+                0xc000..=0xfdff => $crate::diag::PROFILE.reads_wram += 1,
+                0xfe00..=0xfe9f => $crate::diag::PROFILE.reads_oam += 1,
+                0xff80..=0xfffe => $crate::diag::PROFILE.reads_hram += 1,
+                _ => $crate::diag::PROFILE.reads_io += 1,
+            }
+        }
+    }};
+}
+
+#[cfg(not(feature = "profile"))]
+#[macro_export]
+macro_rules! profile_read_gb {
+    ($addr:expr) => {
+        ()
+    };
+}
+
+#[cfg(feature = "profile")]
+#[macro_export]
+macro_rules! profile_write_gb {
+    ($addr:expr) => {{
+        let addr = $addr;
+        unsafe {
+            match addr {
+                0x0000..=0x7fff => $crate::diag::PROFILE.writes_rom += 1,
+                0x8000..=0x9fff => $crate::diag::PROFILE.writes_vram += 1,
+                0xa000..=0xbfff => $crate::diag::PROFILE.writes_eram += 1,
+                0xc000..=0xfdff => $crate::diag::PROFILE.writes_wram += 1,
+                0xfe00..=0xfe9f => $crate::diag::PROFILE.writes_oam += 1,
+                0xff80..=0xfffe => $crate::diag::PROFILE.writes_hram += 1,
+                _ => $crate::diag::PROFILE.writes_io += 1,
+            }
+        }
+    }};
+}
+
+#[cfg(not(feature = "profile"))]
+#[macro_export]
+macro_rules! profile_write_gb {
+    ($addr:expr) => {
+        ()
+    };
+}
+
+#[cfg(all(test, feature = "profile"))]
+mod tests {
+    use super::Profile;
+    use crate::gb::GameBoy;
+
+    /// Tests that the render, read and write totals are computed
+    /// correctly from the individual metric values.
+    #[test]
+    fn test_totals() {
+        let mut profile = Profile::new();
+        profile.render_bg_time = 2;
+        profile.render_obj_time = 3;
+        profile.reads_rom = 1;
+        profile.reads_wram = 2;
+        profile.reads_hram = 3;
+        profile.writes_vram = 4;
+        profile.writes_oam = 5;
+        profile.writes_io = 6;
+
+        assert_eq!(profile.render_time(), 5);
+        assert_eq!(profile.total_reads(), 6);
+        assert_eq!(profile.total_writes(), 15);
+    }
+
+    /// Tests that the description of the profile contains the
+    /// complete set of gathered metrics.
+    #[test]
+    fn test_description() {
+        let mut profile = Profile::new();
+        profile.frame_time = 1000000;
+        profile.frames = 60;
+        profile.instructions = 1024;
+
+        let description = profile.description();
+        assert!(description.contains("Frame"));
+        assert!(description.contains("Render BG"));
+        assert!(description.contains("Render OBJ"));
+        assert!(description.contains("Frames        60"));
+        assert!(description.contains("Instructions  1024"));
+        assert!(description.contains("Reads"));
+        assert!(description.contains("Writes"));
+    }
+
+    /// Tests that the profile macros update the global profile
+    /// instance and that the reset operation clears it.
+    #[test]
+    fn test_profile_macros() {
+        GameBoy::reset_profile();
+
+        profile_count_gb!(instructions);
+        let result = profile_time_gb!(frame_time, 42);
+        profile_read_gb!(0xc000u16);
+        profile_write_gb!(0xff80u16);
+
+        let profile = GameBoy::profile();
+        assert_eq!(result, 42);
+        assert_eq!(profile.instructions, 1);
+        assert_eq!(profile.reads_wram, 1);
+        assert_eq!(profile.writes_hram, 1);
+
+        GameBoy::reset_profile();
+        let profile = GameBoy::profile();
+        assert_eq!(profile.instructions, 0);
+        assert_eq!(profile.reads_wram, 0);
+        assert_eq!(profile.writes_hram, 0);
+    }
 }

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -157,6 +157,8 @@ pub enum GameBoySpeed {
 }
 
 impl GameBoySpeed {
+    /// Human readable description of the current speed mode,
+    /// to be used mostly for display purposes.
     pub fn description(&self) -> &'static str {
         match self {
             GameBoySpeed::Normal => "Normal Speed",
@@ -164,6 +166,9 @@ impl GameBoySpeed {
         }
     }
 
+    /// Speed mode that results from a speed switch operation,
+    /// effectively toggling between the two available speed
+    /// modes (used by the KEY1 register in CGB mode).
     pub fn switch(&self) -> Self {
         match self {
             GameBoySpeed::Normal => GameBoySpeed::Double,
@@ -171,6 +176,9 @@ impl GameBoySpeed {
         }
     }
 
+    /// Number of times the clock runs faster than the base
+    /// (normal) speed, to be used as the reference value in
+    /// cycle normalization operations.
     pub fn multiplier(&self) -> u8 {
         match self {
             GameBoySpeed::Normal => 1,
@@ -188,6 +196,9 @@ impl GameBoySpeed {
         }
     }
 
+    /// Converts the provided `u8` value into the corresponding
+    /// speed mode, panicking in case the value does not represent
+    /// a valid speed mode.
     pub fn from_u8(value: u8) -> Self {
         match value {
             0 => GameBoySpeed::Normal,

--- a/src/gb.rs
+++ b/src/gb.rs
@@ -54,6 +54,7 @@ use crate::{
         FRAME_BUFFER_RGB565_SIZE, FRAME_BUFFER_RGBA_SIZE, FRAME_BUFFER_SIZE,
         FRAME_BUFFER_XRGB8888_SIZE,
     },
+    profile_count_gb, profile_time_gb,
     rom::{Cartridge, RamSize},
     serial::{NullDevice, Serial, SerialDevice},
     timer::Timer,
@@ -174,6 +175,16 @@ impl GameBoySpeed {
         match self {
             GameBoySpeed::Normal => 1,
             GameBoySpeed::Double => 2,
+        }
+    }
+
+    /// Number of bits to shift a cycle count by to normalize
+    /// it according to the current speed, equivalent to a
+    /// division by the [`GameBoySpeed::multiplier()`] value.
+    pub fn shift(&self) -> u8 {
+        match self {
+            GameBoySpeed::Normal => 0,
+            GameBoySpeed::Double => 1,
         }
     }
 
@@ -615,7 +626,7 @@ impl GameBoy {
     #[inline(always)]
     pub fn clock(&mut self) -> u16 {
         let cycles = self.cpu_clock() as u16;
-        let cycles_n = cycles / self.multiplier() as u16;
+        let cycles_n = cycles >> self.speed().shift();
         self.clock_devices(cycles, cycles_n);
         cycles
     }
@@ -635,7 +646,7 @@ impl GameBoy {
         for _ in 0..count {
             cycles += self.cpu_clock() as u16;
         }
-        let cycles_n = cycles / self.multiplier() as u16;
+        let cycles_n = cycles >> self.speed().shift();
         self.clock_devices(cycles, cycles_n);
         cycles
     }
@@ -649,7 +660,7 @@ impl GameBoy {
         if self.cpu_i().pc() == addr {
             return cycles;
         }
-        let cycles_n = cycles / self.multiplier() as u16;
+        let cycles_n = cycles >> self.speed().shift();
         self.clock_devices(cycles, cycles_n);
         cycles
     }
@@ -713,12 +724,15 @@ impl GameBoy {
     /// is reached and returns the amount of cycles that have been
     /// clocked.
     pub fn next_frame(&mut self) -> u32 {
-        let mut cycles = 0u32;
-        let current_frame = self.ppu_frame();
-        while self.ppu_frame() == current_frame {
-            cycles += self.clock() as u32;
-        }
-        cycles
+        profile_count_gb!(frames);
+        profile_time_gb!(frame_time, {
+            let mut cycles = 0u32;
+            let current_frame = self.ppu_frame();
+            while self.ppu_frame() == current_frame {
+                cycles += self.clock() as u32;
+            }
+            cycles
+        })
     }
 
     /// Clocks the system until the Program Counter (PC) reaches the
@@ -777,6 +791,7 @@ impl GameBoy {
 
     #[inline(always)]
     pub fn cpu_clock(&mut self) -> u8 {
+        profile_count_gb!(instructions);
         self.cpu.clock()
     }
 
@@ -1745,5 +1760,21 @@ impl Default for GameBoy {
 impl Display for GameBoy {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description(9))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GameBoySpeed;
+
+    /// Tests that the speed shift value is equivalent to a division
+    /// by the speed multiplier when normalizing cycle counts.
+    #[test]
+    fn test_speed_shift() {
+        for speed in [GameBoySpeed::Normal, GameBoySpeed::Double] {
+            for cycles in [0u16, 4, 8, 12, 16, 20, 24] {
+                assert_eq!(cycles >> speed.shift(), cycles / speed.multiplier() as u16);
+            }
+        }
     }
 }

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -12,6 +12,7 @@ use crate::{
     pad::Pad,
     panic_gb,
     ppu::{Ppu, PpuMode},
+    profile_read_gb, profile_write_gb,
     rom::Cartridge,
     serial::Serial,
     timer::Timer,
@@ -383,6 +384,7 @@ impl Mmu {
     }
 
     pub fn read(&self, addr: u16) -> u8 {
+        profile_read_gb!(addr);
         match addr {
             // 0x0000-0x0FFF - BOOT (256 B) + ROM0 (4 KB/16 KB)
             0x0000..=0x0fff => {
@@ -496,6 +498,7 @@ impl Mmu {
     }
 
     pub fn write(&mut self, addr: u16, value: u8) {
+        profile_write_gb!(addr);
         match addr {
             // 0x0000-0x0FFF - BOOT (256 B) + ROM0 (4 KB/16 KB)
             // 0x1000-0x3FFF - ROM 0 (12 KB/16 KB)

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     gb::{GameBoyConfig, GameBoyMode},
     mmu::BusComponent,
-    panic_gb,
+    panic_gb, profile_count_gb, profile_time_gb,
     state::{StateComponent, StateFormat},
     warnln,
 };
@@ -213,10 +213,12 @@ impl Tile {
         Self { buffer: [0u8; 64] }
     }
 
+    #[inline(always)]
     pub fn get(&self, x: usize, y: usize) -> u8 {
         self.buffer[y * TILE_WIDTH + x]
     }
 
+    #[inline(always)]
     pub fn get_flipped(&self, x: usize, y: usize, xflip: bool, yflip: bool) -> u8 {
         let x: usize = if xflip { TILE_WIDTH_I - x } else { x };
         let y = if yflip { TILE_HEIGHT_I - y } else { y };
@@ -233,6 +235,7 @@ impl Tile {
 }
 
 impl Tile {
+    #[inline(always)]
     pub fn get_row(&self, y: usize) -> &[u8] {
         &self.buffer[y * TILE_WIDTH..(y + 1) * TILE_WIDTH]
     }
@@ -1683,6 +1686,7 @@ impl Ppu {
     }
 
     fn render_line(&mut self) {
+        profile_count_gb!(render_lines);
         let start_x = self.line_cursor as usize;
         if self.gb_mode == GameBoyMode::Dmg {
             self.render_line_dmg(start_x, DISPLAY_WIDTH, true);
@@ -1728,31 +1732,37 @@ impl Ppu {
             return;
         }
         if self.switch_bg {
-            self.render_map_dmg(
-                self.bg_map,
-                self.scx,
-                self.scy,
-                0,
-                0,
-                self.ly,
-                start_x,
-                end_x,
+            profile_time_gb!(
+                render_bg_time,
+                self.render_map_dmg(
+                    self.bg_map,
+                    self.scx,
+                    self.scy,
+                    0,
+                    0,
+                    self.ly,
+                    start_x,
+                    end_x,
+                )
             );
         }
         if self.switch_bg && self.switch_window {
-            self.render_map_dmg(
-                self.window_map,
-                0,
-                0,
-                self.wx,
-                self.wy,
-                self.window_counter,
-                start_x,
-                end_x,
+            profile_time_gb!(
+                render_bg_time,
+                self.render_map_dmg(
+                    self.window_map,
+                    0,
+                    0,
+                    self.wx,
+                    self.wy,
+                    self.window_counter,
+                    start_x,
+                    end_x,
+                )
             );
         }
         if objects && self.switch_obj {
-            self.render_objects();
+            profile_time_gb!(render_obj_time, self.render_objects());
         }
     }
 
@@ -1762,31 +1772,37 @@ impl Ppu {
         }
         let switch_bg_window = (self.gb_mode.is_cgb() && !self.dmg_compat) || self.switch_bg;
         if switch_bg_window {
-            self.render_map(
-                self.bg_map,
-                self.scx,
-                self.scy,
-                0,
-                0,
-                self.ly,
-                start_x,
-                end_x,
+            profile_time_gb!(
+                render_bg_time,
+                self.render_map(
+                    self.bg_map,
+                    self.scx,
+                    self.scy,
+                    0,
+                    0,
+                    self.ly,
+                    start_x,
+                    end_x,
+                )
             );
         }
         if switch_bg_window && self.switch_window {
-            self.render_map(
-                self.window_map,
-                0,
-                0,
-                self.wx,
-                self.wy,
-                self.window_counter,
-                start_x,
-                end_x,
+            profile_time_gb!(
+                render_bg_time,
+                self.render_map(
+                    self.window_map,
+                    0,
+                    0,
+                    self.wx,
+                    self.wy,
+                    self.window_counter,
+                    start_x,
+                    end_x,
+                )
             );
         }
         if objects && self.switch_obj {
-            self.render_objects();
+            profile_time_gb!(render_obj_time, self.render_objects());
         }
     }
 
@@ -2053,9 +2069,6 @@ impl Ppu {
             tile_index += 256;
         }
 
-        // obtains the reference to the tile that is going to be drawn
-        let mut tile = &self.tiles[tile_index];
-
         // calculates the offset that is going to be used in the update of the color buffer
         // which stores Game Boy colors from 0 to 3
         let mut color_offset = self.ly as usize * DISPLAY_WIDTH;
@@ -2069,6 +2082,10 @@ impl Ppu {
         let y = (ld as usize + scy as usize) & 0x07;
         let mut x = line_x & 0x07;
 
+        // obtains the reference to the row of the tile that is going
+        // to be drawn, this avoids a per pixel tile buffer indexing
+        let mut tile_row = self.tiles[tile_index].get_row(y);
+
         // offsets the color buffer position by the start index,
         // skipping the pixels that are not going to be drawn
         color_offset += start_index;
@@ -2078,8 +2095,8 @@ impl Ppu {
         // to skip the drawing of the tiles that are not visible (WX) or
         // that have already been drawn (partial line rendering)
         for _ in start_index..end_x {
-            // obtains the current pixel data from the tile
-            let pixel = tile.get(x, y);
+            // obtains the current pixel data from the tile row
+            let pixel = tile_row[x];
 
             // updates the pixel in the color buffer, which stores
             // the raw pixel color information (unmapped) and then
@@ -2108,8 +2125,8 @@ impl Ppu {
                     tile_index += 256;
                 }
 
-                // obtains the reference to the new tile in drawing
-                tile = &self.tiles[tile_index];
+                // obtains the reference to the row of the new tile in drawing
+                tile_row = self.tiles[tile_index].get_row(y);
             }
 
             // increments the color offset by one, representing
@@ -2147,6 +2164,15 @@ impl Ppu {
             false
         };
 
+        // calculates the height of the objects that is going to be
+        // used in the sprite containment verification, the value
+        // is the same for all of the objects in the current line
+        let obj_height = if self.obj_size {
+            TILE_DOUBLE_HEIGHT
+        } else {
+            TILE_HEIGHT
+        };
+
         // iterates over the complete set of available object to check
         // the ones that require drawing and draws them
         for index in 0..OBJ_COUNT {
@@ -2159,12 +2185,6 @@ impl Ppu {
             // obtains the meta data of the object that is currently
             // under iteration to be checked for drawing
             let obj = &self.obj_data[index];
-
-            let obj_height = if self.obj_size {
-                TILE_DOUBLE_HEIGHT
-            } else {
-                TILE_HEIGHT
-            };
 
             // verifies if the sprite is currently located at the
             // current line that is going to be drawn and skips it
@@ -2648,6 +2668,26 @@ mod tests {
         gb::GameBoyMode,
         state::{StateComponent, StateFormat},
     };
+
+    /// Tests that the tile row access is equivalent to the per
+    /// pixel access for the complete tile surface.
+    #[test]
+    fn test_tile_get_row() {
+        let mut tile = Tile::new();
+        for y in 0..8 {
+            for x in 0..8 {
+                tile.set(x, y, ((y * 8 + x) % 4) as u8);
+            }
+        }
+
+        for y in 0..8 {
+            let row = tile.get_row(y);
+            assert_eq!(row.len(), 8);
+            for (x, pixel) in row.iter().enumerate() {
+                assert_eq!(*pixel, tile.get(x, y));
+            }
+        }
+    }
 
     #[test]
     fn test_clear_screen_pending_vblank() {

--- a/src/ppu.rs
+++ b/src/ppu.rs
@@ -1826,11 +1826,12 @@ impl Ppu {
 
         // selects the correct background attributes map based on the bg map flag
         // because the attributes are separated according to the map they represent
-        // this is only relevant for CGB mode
+        // this is only relevant for CGB mode, the map is borrowed to avoid
+        // an expensive copy of the complete attributes buffer per line
         let bg_map_attrs = if map {
-            self.bg_map_attrs_1
+            &self.bg_map_attrs_1
         } else {
-            self.bg_map_attrs_0
+            &self.bg_map_attrs_0
         };
 
         // obtains the base address of the background map using the bg map flag
@@ -1913,9 +1914,6 @@ impl Ppu {
         // bank in which the tile is stored, this is only required for CGB mode
         tile_index += tile_attr.vram_bank as usize * TILE_COUNT_DMG;
 
-        // obtains the reference to the tile that is going to be drawn
-        let mut tile = &self.tiles[tile_index];
-
         // calculates the offset that is going to be used in the update of the color buffer
         // which stores Game Boy colors from 0 to 3
         let mut color_offset = self.ly as usize * DISPLAY_WIDTH;
@@ -1929,6 +1927,12 @@ impl Ppu {
         let y = (ld as usize + scy as usize) & 0x07;
         let mut x = line_x & 0x07;
 
+        // obtains the reference to the row of the tile that is going
+        // to be drawn, taking into consideration the Y flip attribute,
+        // this avoids a per pixel tile buffer indexing
+        let mut tile_row =
+            self.tiles[tile_index].get_row(if yflip { TILE_HEIGHT_I - y } else { y });
+
         // offsets both the color and the frame buffer positions by the
         // start index, skipping the pixels that are not going to be drawn
         color_offset += start_index;
@@ -1939,8 +1943,9 @@ impl Ppu {
         // to skip the drawing of the tiles that are not visible (WX) or
         // that have already been drawn (partial line rendering)
         for _ in start_index..end_x {
-            // obtains the current pixel data from the tile
-            let pixel = tile.get_flipped(x, y, xflip, yflip);
+            // obtains the current pixel data from the tile row
+            // taking into consideration the X flip attribute
+            let pixel = tile_row[if xflip { TILE_WIDTH_I - x } else { x }];
 
             // updates the pixel in the color buffer, which stores
             // the raw pixel color information (unmapped) and then
@@ -1994,8 +1999,9 @@ impl Ppu {
                     tile_index += tile_attr.vram_bank as usize * TILE_COUNT_DMG;
                 }
 
-                // obtains the reference to the new tile in drawing
-                tile = &self.tiles[tile_index];
+                // obtains the reference to the row of the new tile in drawing
+                tile_row =
+                    self.tiles[tile_index].get_row(if yflip { TILE_HEIGHT_I - y } else { y });
             }
 
             // increments the color offset by one, representing
@@ -2661,7 +2667,7 @@ impl Default for Ppu {
 mod tests {
     use super::{
         ObjectData, Ppu, PpuMode, Tile, COLOR_BUFFER_SIZE, FRAME_BUFFER_SIZE, HRAM_SIZE, OAM_SIZE,
-        OBJ_COUNT, SHADE_BUFFER_SIZE, TILE_COUNT, VRAM_SIZE,
+        OBJ_COUNT, SHADE_BUFFER_SIZE, TILE_COUNT, TILE_HEIGHT_I, TILE_WIDTH_I, VRAM_SIZE,
     };
     use crate::{
         consts::LCDC_ADDR,
@@ -2685,6 +2691,29 @@ mod tests {
             assert_eq!(row.len(), 8);
             for (x, pixel) in row.iter().enumerate() {
                 assert_eq!(*pixel, tile.get(x, y));
+            }
+        }
+    }
+
+    /// Tests that the tile row access with flip aware indexing is
+    /// equivalent to the flipped per pixel access for all of the
+    /// flip combinations.
+    #[test]
+    fn test_tile_get_row_flipped() {
+        let mut tile = Tile::new();
+        for y in 0..8 {
+            for x in 0..8 {
+                tile.set(x, y, ((y * 8 + x) % 4) as u8);
+            }
+        }
+
+        for (xflip, yflip) in [(false, false), (true, false), (false, true), (true, true)] {
+            for y in 0..8 {
+                let row = tile.get_row(if yflip { TILE_HEIGHT_I - y } else { y });
+                for x in 0..8 {
+                    let pixel = row[if xflip { TILE_WIDTH_I - x } else { x }];
+                    assert_eq!(pixel, tile.get_flipped(x, y, xflip, yflip));
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Structured performance audit of the emulation core, with local head-to-head benchmarks against mGBA, a set of safe hot-path optimizations and new feature-gated profiling instrumentation for visibility over the emulator internals.

Closes #34

## Changes

- New `profile` feature (mirroring the existing `pedantic` diagnostics pattern) with frame/render wall-time attribution and instruction, render-line, APU-sample and per-region MMU access counters. Zero footprint when disabled; reported by `bench_headless`.
- Interrupt flag synthesis in `Cpu::clock()` is skipped when it cannot affect execution (IME disabled and not halted, or empty IE).
- Cycle normalization uses `GameBoySpeed::shift()` instead of a per-clock integer division.
- DMG background rendering fetches a tile row slice per tile (same approach as `render_objects`) instead of a per-pixel tile buffer index; `Tile` accessors are `#[inline(always)]`; object height is hoisted out of the per-object loop.
- `bench_headless` gains `--apu` and `--cgb` flags for fair cross-emulator comparisons.
- New `doc/performance.md` with methodology, results, audit findings and ranked future work (cached IF register, event-driven scheduling, page-table MMU).

## Results

- `cpu_cycles` criterion benchmark: 510 us → 445 us (~13% faster).
- Frame throughput: +1% to +6% depending on workload, no regressions.
- vs mGBA (audio enabled on both): Boytacean ~1.4-1.7x faster on typical DMG workloads; mGBA ~1.9x faster on interrupt-heavy games and ~2.2x on CGB, explained by its event-driven scheduler (documented as future work).

## Verification

- Emulation output is bit-exact: frame-buffer hashes over dmg-acid2, cgb-acid2 and multiple game ROMs (DMG and CGB modes) match `master` exactly.
- `cargo test --all-targets --features simd,debug,python` passes (53 tests, including 4 new ones); `cargo fmt` and `clippy` clean; wasm feature check passes.
- Benchmarks were run interleaved (best of 3 x 12000 frames) to bound scheduling/thermal noise.